### PR TITLE
Use Monynha Tech branding on posts and search

### DIFF
--- a/src/app/(frontend)/posts/page.tsx
+++ b/src/app/(frontend)/posts/page.tsx
@@ -58,6 +58,6 @@ export default async function Page() {
 
 export function generateMetadata(): Metadata {
   return {
-    title: `Payload Website Template Posts`,
+    title: `Monynha Tech Posts`,
   }
 }

--- a/src/app/(frontend)/posts/page/[pageNumber]/page.tsx
+++ b/src/app/(frontend)/posts/page/[pageNumber]/page.tsx
@@ -65,7 +65,7 @@ export default async function Page({ params: paramsPromise }: Args) {
 export async function generateMetadata({ params: paramsPromise }: Args): Promise<Metadata> {
   const { pageNumber } = await paramsPromise
   return {
-    title: `Payload Website Template Posts Page ${pageNumber || ''}`,
+    title: `Monynha Tech Posts Page ${pageNumber || ''}`,
   }
 }
 

--- a/src/app/(frontend)/search/page.tsx
+++ b/src/app/(frontend)/search/page.tsx
@@ -83,6 +83,6 @@ export default async function Page({ searchParams: searchParamsPromise }: Args) 
 
 export function generateMetadata(): Metadata {
   return {
-    title: `Payload Website Template Search`,
+    title: `Monynha Tech Search`,
   }
 }

--- a/tests/e2e/frontend.e2e.spec.ts
+++ b/tests/e2e/frontend.e2e.spec.ts
@@ -17,4 +17,24 @@ test.describe('Frontend', () => {
 
     await expect(heading).toHaveText('Monynha Tech')
   })
+
+  test('can go on posts page', async ({ page }) => {
+    await page.goto('http://localhost:3000/posts')
+
+    await expect(page).toHaveTitle(/Monynha Tech Posts/)
+
+    const heading = page.locator('h1').first()
+
+    await expect(heading).toHaveText('Posts')
+  })
+
+  test('can go on search page', async ({ page }) => {
+    await page.goto('http://localhost:3000/search')
+
+    await expect(page).toHaveTitle(/Monynha Tech Search/)
+
+    const heading = page.locator('h1').first()
+
+    await expect(heading).toHaveText('Search')
+  })
 })


### PR DESCRIPTION
## Summary
- replace template titles with Monynha Tech on posts and search pages
- extend frontend e2e tests for posts and search titles and headings

## Testing
- `pnpm lint` *(fails: Cannot find package '@eslint/js')*
- `pnpm test:e2e` *(fails: /workspace/monynha-nexus-lab/playwright.config.ts does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_68979e04049483228da52b53ad59d3f1