### PR TITLE
feat: add error boundary and server error page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -21,6 +21,8 @@ import ProjectsIndex from "./pages/ProjectsIndex";
 import ProjectDetail from "./pages/ProjectDetail";
 import DocsIndex from "./pages/DocsIndex";
 import DocPage from "./pages/DocPage";
+import ErrorBoundary from "./pages/ErrorBoundary";
+import ServerError from "./pages/ServerError";
 
 const queryClient = new QueryClient();
 
@@ -32,26 +34,29 @@ const App = () => (
           <Toaster />
           <Sonner />
           <BrowserRouter>
-            <Routes>
-              <Route path="/" element={<Index />} />
-              <Route path="/search" element={<SearchResults />} />
-              <Route path="/blog" element={<BlogIndex />} />
-              <Route path="/blog/:slug" element={<BlogPost />} />
-              <Route path="/projects" element={<ProjectsIndex />} />
-              <Route path="/projects/:slug" element={<ProjectDetail />} />
-              <Route path="/docs" element={<DocsIndex />} />
-              <Route path="/docs/:slug" element={<DocPage />} />
-              <Route path="/auth" element={<Auth />} />
-              <Route path="/admin" element={<AdminLayout />}>
-                <Route index element={<Dashboard />} />
-                <Route path="posts" element={<BlogPosts />} />
-                <Route path="projects" element={<Projects />} />
-                <Route path="authors" element={<Authors />} />
-                <Route path="categories" element={<Categories />} />
-              </Route>
-              {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
-              <Route path="*" element={<NotFound />} />
-            </Routes>
+            <ErrorBoundary>
+              <Routes>
+                <Route path="/" element={<Index />} />
+                <Route path="/search" element={<SearchResults />} />
+                <Route path="/blog" element={<BlogIndex />} />
+                <Route path="/blog/:slug" element={<BlogPost />} />
+                <Route path="/projects" element={<ProjectsIndex />} />
+                <Route path="/projects/:slug" element={<ProjectDetail />} />
+                <Route path="/docs" element={<DocsIndex />} />
+                <Route path="/docs/:slug" element={<DocPage />} />
+                <Route path="/auth" element={<Auth />} />
+                <Route path="/admin" element={<AdminLayout />}> 
+                  <Route index element={<Dashboard />} />
+                  <Route path="posts" element={<BlogPosts />} />
+                  <Route path="projects" element={<Projects />} />
+                  <Route path="authors" element={<Authors />} />
+                  <Route path="categories" element={<Categories />} />
+                </Route>
+                <Route path="/500" element={<ServerError />} />
+                {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
+                <Route path="*" element={<NotFound />} />
+              </Routes>
+            </ErrorBoundary>
           </BrowserRouter>
         </TooltipProvider>
       </LanguageProvider>

--- a/src/pages/ErrorBoundary.test.tsx
+++ b/src/pages/ErrorBoundary.test.tsx
@@ -1,0 +1,60 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import { MemoryRouter, Routes, Route } from 'react-router-dom';
+import { LanguageProvider, useLanguage } from '@/hooks/useLanguage';
+import { useEffect } from 'react';
+import ErrorBoundary from './ErrorBoundary';
+import ServerError from './ServerError';
+
+const Boom = () => {
+  throw new Error('boom');
+};
+
+const LanguageSetter = ({ lang }: { lang: 'pt' | 'en' }) => {
+  const { setLanguage } = useLanguage();
+  useEffect(() => {
+    setLanguage(lang);
+  }, [lang, setLanguage]);
+  return null;
+};
+
+const renderWithLang = (lang: 'pt' | 'en') => {
+  render(
+    <LanguageProvider>
+      <LanguageSetter lang={lang} />
+      <MemoryRouter initialEntries={["/"]}>
+        <Routes>
+          <Route
+            path="/"
+            element={
+              <ErrorBoundary>
+                <Boom />
+              </ErrorBoundary>
+            }
+          />
+          <Route path="/500" element={<ServerError />} />
+        </Routes>
+      </MemoryRouter>
+    </LanguageProvider>
+  );
+};
+
+describe('ErrorBoundary', () => {
+  it('shows Portuguese fallback', async () => {
+    renderWithLang('pt');
+    await waitFor(() => {
+      expect(
+        screen.getByText('Erro interno do servidor')
+      ).toBeInTheDocument();
+    });
+  });
+
+  it('shows English fallback', async () => {
+    renderWithLang('en');
+    await waitFor(() => {
+      expect(
+        screen.getByText('Internal server error')
+      ).toBeInTheDocument();
+    });
+  });
+});

--- a/src/pages/ErrorBoundary.tsx
+++ b/src/pages/ErrorBoundary.tsx
@@ -1,0 +1,34 @@
+import { Component, ErrorInfo, ReactNode } from "react";
+import { Navigate } from "react-router-dom";
+
+interface Props {
+  children: ReactNode;
+}
+
+interface State {
+  hasError: boolean;
+}
+
+class ErrorBoundary extends Component<Props, State> {
+  constructor(props: Props) {
+    super(props);
+    this.state = { hasError: false };
+  }
+
+  static getDerivedStateFromError() {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error: Error, errorInfo: ErrorInfo) {
+    console.error("Unhandled error caught by ErrorBoundary:", error, errorInfo);
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return <Navigate to="/500" replace />;
+    }
+    return this.props.children;
+  }
+}
+
+export default ErrorBoundary;

--- a/src/pages/ServerError.tsx
+++ b/src/pages/ServerError.tsx
@@ -1,0 +1,20 @@
+import { useLanguage } from "@/hooks/useLanguage";
+
+const ServerError = () => {
+  const { t } = useLanguage();
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-gray-100">
+      <div className="text-center">
+        <h1 className="text-4xl font-bold mb-4">500</h1>
+        <p className="text-xl text-gray-600 mb-4">
+          {t("Erro interno do servidor", "Internal server error")}
+        </p>
+        <a href="/" className="text-blue-500 hover:text-blue-700 underline">
+          {t("Voltar para a home", "Back to home")}
+        </a>
+      </div>
+    </div>
+  );
+};
+
+export default ServerError;

--- a/tests/server-error.spec.ts
+++ b/tests/server-error.spec.ts
@@ -1,0 +1,6 @@
+import { test, expect } from '@playwright/test';
+
+test('renders server error page', async ({ page }) => {
+  await page.goto('/500');
+  await expect(page.getByText('Internal server error')).toBeVisible();
+});


### PR DESCRIPTION
## Summary
- wrap routes with error boundary
- add translated 500 page
- add unit and e2e tests for server error handling

## Testing
- `pnpm lint` *(fails: Unexpected any...)*
- `npm test` *(fails: Missing script)*
- `pnpm test:e2e` *(fails: Command not found)*

## Checklist de Entrega
- [x] Funcionalidade concluída e manual de teste incluído
- [ ] Testes: unit + component + e2e (verde)
- [ ] Migrations aplicáveis + RLS/Policies revisadas
- [x] i18n cobrindo PT/EN (fallback ok)
- [ ] A11y básica (sem erros axe/lighthouse críticos)
- [ ] Desempenho dentro do budget
- [ ] Docs/README/CHANGELOG atualizados
- [x] Sem segredos vazando; service key apenas server/CI
- [ ] Capturas de tela ou vídeo curto (quando visual)


------
https://chatgpt.com/codex/tasks/task_e_689875e4488c832294549af6b7570336