### PR TITLE
chore: add environment script and CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,23 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'pnpm'
+      - run: corepack enable
+      - run: pnpm install --frozen-lockfile
+      - run: pnpm exec playwright install --with-deps
+      - run: pnpm lint
+      - run: pnpm exec tsc --noEmit
+      - run: pnpm test
+      - run: pnpm test:e2e

--- a/agent_environment.sh
+++ b/agent_environment.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Ensure pnpm is installed
+if ! command -v pnpm >/dev/null 2>&1; then
+  npm install -g pnpm
+fi
+
+# Install node dependencies
+pnpm install
+
+# Setup environment variables
+if [ -f .env.agents.example ] && [ ! -f .env.local ]; then
+  cp .env.agents.example .env.local
+elif [ -f .env.example ] && [ ! -f .env.local ]; then
+  cp .env.example .env.local
+fi
+
+# Install Playwright browsers and system dependencies
+pnpm exec playwright install --with-deps
+
+# Start Supabase and run migrations if Docker is available
+if command -v docker >/dev/null 2>&1; then
+  pnpm dlx supabase start
+  pnpm dlx supabase db reset --force --no-interaction
+else
+  echo "Docker not installed; skipping Supabase start and migrations."
+fi

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,4 +1,5 @@
 import { defineConfig } from "vite";
+import { configDefaults } from "vitest/config";
 import react from "@vitejs/plugin-react-swc";
 import path from "path";
 import { componentTagger } from "lovable-tagger";
@@ -23,5 +24,6 @@ export default defineConfig(({ mode }) => ({
     environment: "jsdom",
     globals: true,
     setupFiles: "./src/test/setup.ts",
+    exclude: [...configDefaults.exclude, "tests/**"],
   },
 }));


### PR DESCRIPTION
## Summary
- add agent_environment.sh for local setup
- configure vitest to skip E2E specs
- run lint, type-check, and tests in CI

## Testing
- `./agent_environment.sh`
- `pnpm test`
- `pnpm test:e2e`

## Checklist
- [ ] Funcionalidade concluída e manual de teste incluído
- [x] Testes: unit + component + e2e (verde)
- [ ] Migrations aplicáveis + RLS/Policies revisadas
- [ ] i18n cobrindo PT/EN (fallback ok)
- [ ] A11y básica (sem erros axe/lighthouse críticos)
- [ ] Desempenho dentro do budget
- [ ] Docs/README/CHANGELOG atualizados
- [x] Sem segredos vazando; service key apenas server/CI
- [ ] Capturas de tela ou vídeo curto (quando visual)


------
https://chatgpt.com/codex/tasks/task_e_68988b0e06588322952b449ddf0e1ac5