### PR TITLE
feat: add comments table with rls

### DIFF
--- a/supabase/migrations/20250810130638_create_comments.sql
+++ b/supabase/migrations/20250810130638_create_comments.sql
@@ -1,0 +1,31 @@
+create table if not exists public.comments (
+  id uuid primary key default gen_random_uuid(),
+  post_id uuid references public.blog_posts(id) on delete cascade,
+  name text not null,
+  email text,
+  content text not null,
+  approved boolean default false,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+alter table public.comments enable row level security;
+
+create or replace trigger trg_comments_updated
+  before update on public.comments
+  for each row execute function public.update_updated_at_column();
+
+create policy "Read approved comments"
+  on public.comments for select
+  using (approved = true);
+
+create policy "Anon can insert comment"
+  on public.comments for insert
+  to anon
+  with check (true);
+
+create policy "Authenticated can update comment"
+  on public.comments for update
+  to authenticated
+  using (true)
+  with check (true);


### PR DESCRIPTION
## Summary
- add comments table with RLS policies for select, insert, and update

## Testing
- `npx --yes supabase db reset` *(fails: Cannot connect to the Docker daemon)*
- `pnpm test`

## Checklist
- [ ] Funcionalidade concluída e manual de teste incluído
- [ ] Testes: unit + component + e2e (verde)
- [ ] Migrations aplicáveis + RLS/Policies revisadas
- [ ] i18n cobrindo PT/EN (fallback ok)
- [ ] A11y básica (sem erros axe/lighthouse críticos)
- [ ] Desempenho dentro do budget
- [ ] Docs/README/CHANGELOG atualizados
- [ ] Sem segredos vazando; service key apenas server/CI
- [ ] Capturas de tela ou vídeo curto (quando visual)


------
https://chatgpt.com/codex/tasks/task_e_6898990a636483229867343c1c3b85cc