### PR TITLE
fix: use npx for Supabase CLI in migrations

### DIFF
--- a/.github/workflows/migrations.yml
+++ b/.github/workflows/migrations.yml
@@ -35,13 +35,10 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 20
-      - name: Install Supabase CLI
-        run: npm install -g supabase@latest
       - name: Dry‑run migrations against staging
         env:
           DATABASE_URL: ${{ vars.STAGING_DATABASE_URL }}
-        run: |
-          supabase db push --db-url "$DATABASE_URL" --dry-run
+      run: npx -y supabase@latest db push --db-url "$DATABASE_URL" --dry-run
 
   deploy:
     if: github.event_name == 'push'
@@ -55,10 +52,8 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 20
-      - name: Install Supabase CLI
-        run: npm install -g supabase@latest
       - name: Apply migrations
         env:
           DATABASE_URL: ${{ vars.PRODUCTION_DATABASE_URL }}
-        run: |
-          supabase db push --db-url "$DATABASE_URL" --include-all
+      run: npx -y supabase@latest db push --db-url "$DATABASE_URL" --include-all
+

--- a/agent_environment.sh
+++ b/agent_environment.sh
@@ -2,10 +2,9 @@
 
 # agent_environment.sh — bootstrap the local development environment for Monynha Nexus Lab.
 #
-# This script installs all required tooling (pnpm and the Supabase CLI),
-# installs project dependencies, and can optionally run a database
-# migration dry‑run when a DATABASE_URL is provided.  It is idempotent
-# and safe to run multiple times.
+# This script installs all required tooling (pnpm), installs project
+# dependencies, and can optionally run a database migration dry‑run when a
+# DATABASE_URL is provided.  It is idempotent and safe to run multiple times.
 
 set -euo pipefail
 
@@ -13,12 +12,6 @@ set -euo pipefail
 if ! command -v pnpm >/dev/null 2>&1; then
   echo "[agent_environment] Installing pnpm…" >&2
   npm install -g pnpm@latest
-fi
-
-# Detect whether the Supabase CLI is available; install via npm if missing.
-if ! command -v supabase >/dev/null 2>&1; then
-  echo "[agent_environment] Installing Supabase CLI…" >&2
-  npm install -g supabase@latest
 fi
 
 # Install project dependencies using pnpm.  The workspace uses a
@@ -32,7 +25,8 @@ pnpm install
 # execute migrations locally, use the provided scripts/migrate.sh.
 if [[ -n "${DATABASE_URL:-}" ]]; then
   echo "[agent_environment] Validating database migrations against provided DATABASE_URL…" >&2
-  supabase db push --db-url "$DATABASE_URL" --dry-run
+  npx -y supabase@latest db push --db-url "$DATABASE_URL" --dry-run
 fi
 
 echo "[agent_environment] Environment setup complete." >&2
+

--- a/ci_test_local.sh
+++ b/ci_test_local.sh
@@ -34,7 +34,8 @@ pnpm test:e2e
 # Dry run migrations if DATABASE_URL is set.
 if [[ -n "${DATABASE_URL:-}" ]]; then
   echo "[ci_test_local] Performing migration dry‑run…" >&2
-  supabase db push --db-url "$DATABASE_URL" --dry-run
+  npx -y supabase@latest db push --db-url "$DATABASE_URL" --dry-run
 fi
 
 echo "[ci_test_local] All local CI checks completed successfully." >&2
+

--- a/scripts/agent_environment.sh
+++ b/scripts/agent_environment.sh
@@ -2,10 +2,9 @@
 
 # agent_environment.sh — bootstrap the local development environment for Monynha Nexus Lab.
 #
-# This script installs all required tooling (pnpm and the Supabase CLI),
-# installs project dependencies, and can optionally run a database
-# migration dry‑run when a DATABASE_URL is provided.  It is idempotent
-# and safe to run multiple times.
+# This script installs all required tooling (pnpm), installs project
+# dependencies, and can optionally run a database migration dry‑run when a
+# DATABASE_URL is provided.  It is idempotent and safe to run multiple times.
 
 set -euo pipefail
 
@@ -13,12 +12,6 @@ set -euo pipefail
 if ! command -v pnpm >/dev/null 2>&1; then
   echo "[agent_environment] Installing pnpm…" >&2
   npm install -g pnpm@latest
-fi
-
-# Detect whether the Supabase CLI is available; install via npm if missing.
-if ! command -v supabase >/dev/null 2>&1; then
-  echo "[agent_environment] Installing Supabase CLI…" >&2
-  npm install -g supabase@latest
 fi
 
 # Install project dependencies using pnpm.  The workspace uses a
@@ -32,7 +25,8 @@ pnpm install
 # execute migrations locally, use the provided scripts/migrate.sh.
 if [[ -n "${DATABASE_URL:-}" ]]; then
   echo "[agent_environment] Validating database migrations against provided DATABASE_URL…" >&2
-  supabase db push --db-url "$DATABASE_URL" --dry-run
+  npx -y supabase@latest db push --db-url "$DATABASE_URL" --dry-run
 fi
 
 echo "[agent_environment] Environment setup complete." >&2
+

--- a/scripts/ci_test_local.sh
+++ b/scripts/ci_test_local.sh
@@ -39,7 +39,8 @@ pnpm test --if-present
 # Dry run migrations if DATABASE_URL is set.
 if [[ -n "${DATABASE_URL:-}" ]]; then
   echo "[ci_test_local] Performing migration dry‑run…" >&2
-  supabase db push --db-url "$DATABASE_URL" --dry-run
+  npx -y supabase@latest db push --db-url "$DATABASE_URL" --dry-run
 fi
 
 echo "[ci_test_local] All local CI checks completed successfully." >&2
+

--- a/scripts/migrate.sh
+++ b/scripts/migrate.sh
@@ -3,18 +3,14 @@
 # scripts/migrate.sh — apply Supabase migrations in a controlled way.
 #
 # This script applies all database migrations defined in the
-# `supabase/migrations` directory against a target database.  It
-# requires the Supabase CLI to be installed and expects either a
-# DATABASE_URL environment variable (preferred) or a Supabase project
-# reference with a service role token.  Use this script in CI/CD
-# pipelines or locally to ensure migrations are applied consistently.
+# `supabase/migrations` directory against a target database.  It expects
+# either a DATABASE_URL environment variable (preferred) or a Supabase
+# project reference with a service role token.  The Supabase CLI is
+# invoked via `npx` so no global installation is required.  Use this
+# script in CI/CD pipelines or locally to ensure migrations are applied
+# consistently.
 
 set -euo pipefail
-
-if ! command -v supabase >/dev/null 2>&1; then
-  echo "[migrate] Supabase CLI is not installed.  Run ./agent_environment.sh first." >&2
-  exit 1
-fi
 
 # Determine connection mode.  Prefer DATABASE_URL if present.  As a
 # fallback, allow PROJECT_REF and SUPABASE_SERVICE_KEY to be used.
@@ -24,7 +20,7 @@ elif [[ -n "${PROJECT_REF:-}" && -n "${SUPABASE_SERVICE_KEY:-}" ]]; then
   CONNECTION_ARGS=(--linked)
   # Link the project using the provided environment variables.  This
   # will write a .supabase/config.json file for subsequent commands.
-  supabase link --project-ref "$PROJECT_REF" --secret "$SUPABASE_SERVICE_KEY" >/dev/null
+  npx -y supabase@latest link --project-ref "$PROJECT_REF" --secret "$SUPABASE_SERVICE_KEY" >/dev/null
 else
   echo "[migrate] Neither DATABASE_URL nor PROJECT_REF/SUPABASE_SERVICE_KEY provided." >&2
   echo "Set DATABASE_URL for remote migrations or PROJECT_REF and SUPABASE_SERVICE_KEY for linked migrations." >&2
@@ -33,11 +29,12 @@ fi
 
 # Dry run: show what will change without applying.
 echo "[migrate] Performing dry‑run of migrations…" >&2
-supabase db push "${CONNECTION_ARGS[@]}" --dry-run
+npx -y supabase@latest db push "${CONNECTION_ARGS[@]}" --dry-run
 
 # Apply migrations.  The --include-all flag ensures that pending
 # migrations are applied in the order they appear.
 echo "[migrate] Applying migrations…" >&2
-supabase db push "${CONNECTION_ARGS[@]}" --include-all
+npx -y supabase@latest db push "${CONNECTION_ARGS[@]}" --include-all
 
 echo "[migrate] Migrations applied successfully." >&2
+


### PR DESCRIPTION
## Summary
- avoid global Supabase CLI install by running via `npx`
- update local helper scripts and migration workflow to use `npx supabase`

## Testing
- `./ci_test_local.sh`

## Checklist
- [ ] Funcionalidade concluída e manual de teste incluído
- [ ] Testes: unit + component + e2e (verde)
- [ ] Migrations aplicáveis + RLS/Policies revisadas
- [ ] i18n cobrindo PT/EN (fallback ok)
- [ ] A11y básica (sem erros axe/lighthouse críticos)
- [ ] Desempenho dentro do budget
- [ ] Docs/README/CHANGELOG atualizados
- [ ] Sem segredos vazando; service key apenas server/CI
- [ ] Capturas de tela ou vídeo curto (quando visual)


------
https://chatgpt.com/codex/tasks/task_e_6898ac4e43288322a734968238daf570