### PR TITLE
feat: add comments hook

### DIFF
--- a/src/hooks/useComments.test.tsx
+++ b/src/hooks/useComments.test.tsx
@@ -1,0 +1,121 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, waitFor, act } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+vi.mock('@/integrations/supabase/client', () => ({
+  supabase: {
+    from: vi.fn(),
+  },
+}));
+
+const { supabase } = await import('@/integrations/supabase/client');
+import { useComments } from './useComments';
+
+function createWrapper() {
+  const queryClient = new QueryClient();
+  return ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+}
+
+describe('useComments', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('fetches approved comments', async () => {
+    const comments = [
+      {
+        id: '1',
+        post_id: '1',
+        name: 'John',
+        email: 'john@example.com',
+        content: 'Hello',
+        approved: true,
+        created_at: '2023-01-01',
+      },
+    ];
+
+    const order = vi.fn().mockResolvedValue({ data: comments, error: null });
+    const match = vi.fn().mockReturnValue({ order });
+    const select = vi.fn().mockReturnValue({ match, order });
+    (supabase.from as any).mockReturnValue({ select });
+
+    const { result } = renderHook(() => useComments('1'), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+    expect(result.current.comments).toEqual(comments);
+    expect(supabase.from).toHaveBeenCalledWith('comments');
+  });
+
+  it('returns error when fetching fails', async () => {
+    const order = vi.fn().mockResolvedValue({ data: null, error: { message: 'fail' } });
+    const match = vi.fn().mockReturnValue({ order });
+    const select = vi.fn().mockReturnValue({ match, order });
+    (supabase.from as any).mockReturnValue({ select });
+
+    const { result } = renderHook(() => useComments('1'), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.error).toBeDefined());
+    expect(result.current.comments).toEqual([]);
+  });
+
+  it('adds a comment successfully', async () => {
+    const order = vi.fn().mockResolvedValue({ data: [], error: null });
+    const match = vi.fn().mockReturnValue({ order });
+    const select = vi.fn().mockReturnValue({ match, order });
+    const insert = vi.fn().mockResolvedValue({ error: null });
+    (supabase.from as any).mockReturnValue({ select, insert });
+
+    const { result } = renderHook(() => useComments('1'), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    act(() => {
+      result.current.mutate({
+        postId: '1',
+        name: 'Jane',
+        email: 'jane@example.com',
+        content: 'Hi',
+      });
+    });
+
+    await waitFor(() => expect(insert).toHaveBeenCalled());
+  });
+
+  it('handles error when adding a comment fails', async () => {
+    const order = vi.fn().mockResolvedValue({ data: [], error: null });
+    const match = vi.fn().mockReturnValue({ order });
+    const select = vi.fn().mockReturnValue({ match, order });
+    const insert = vi.fn().mockResolvedValue({ error: { message: 'insert fail' } });
+    (supabase.from as any).mockReturnValue({ select, insert });
+
+    const { result } = renderHook(() => useComments('1'), {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    act(() => {
+      result.current.mutate({
+        postId: '1',
+        name: 'Jane',
+        email: 'jane@example.com',
+        content: 'Hi',
+      });
+    });
+
+    await waitFor(() => expect(result.current.error).toBeDefined());
+  });
+});
+

--- a/src/hooks/useComments.ts
+++ b/src/hooks/useComments.ts
@@ -1,0 +1,74 @@
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { supabase } from '@/integrations/supabase/client';
+
+export type Comment = {
+  id: string;
+  post_id: string;
+  name: string;
+  email: string | null;
+  content: string;
+  approved: boolean;
+  created_at: string;
+};
+
+interface NewComment {
+  postId: string;
+  name: string;
+  email?: string;
+  content: string;
+}
+
+export function useComments(postId: string) {
+  const queryClient = useQueryClient();
+
+  const {
+    data,
+    isLoading: queryLoading,
+    error: queryError,
+  } = useQuery<Comment[]>({
+    queryKey: ['comments', postId],
+    queryFn: async () => {
+      const { data, error } = await supabase
+        .from('comments')
+        .select('*')
+        .match({ post_id: postId, approved: true })
+        .order('created_at', { ascending: true });
+
+      if (error) {
+        throw new Error(error.message);
+      }
+
+      return (data ?? []) as Comment[];
+    },
+  });
+
+  const {
+    mutate,
+    isPending,
+    error: mutationError,
+  } = useMutation({
+    mutationFn: async ({ postId, name, email, content }: NewComment) => {
+      const { error } = await supabase.from('comments').insert({
+        post_id: postId,
+        name,
+        email,
+        content,
+      });
+
+      if (error) {
+        throw new Error(error.message);
+      }
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['comments', postId] });
+    },
+  });
+
+  return {
+    comments: data ?? [],
+    isLoading: queryLoading || isPending,
+    error: queryError ?? mutationError,
+    mutate,
+  };
+}
+


### PR DESCRIPTION
## Summary
- add React Query hook for fetching and creating comments
- test comment fetching and mutations for success and error cases

## Testing
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_6898b37b25b4832283f29191195d1ab8