### PR TITLE
feat: add comments section with tests

### DIFF
--- a/src/components/Comments.tsx
+++ b/src/components/Comments.tsx
@@ -1,0 +1,96 @@
+import { useState, FormEvent } from 'react';
+import { useComments } from '@/hooks/useComments';
+import { useLanguage } from '@/hooks/useLanguage';
+import { Input } from '@/components/ui/input';
+import { Textarea } from '@/components/ui/textarea';
+import { Button } from '@/components/ui/button';
+import { toast } from '@/components/ui/use-toast';
+
+interface CommentsProps {
+  postId: string;
+}
+
+export function Comments({ postId }: CommentsProps) {
+  const { t } = useLanguage();
+  const { comments, isLoading, error, mutate: addComment } = useComments(postId);
+  const [name, setName] = useState('');
+  const [email, setEmail] = useState('');
+  const [content, setContent] = useState('');
+
+  const handleSubmit = (e: FormEvent) => {
+    e.preventDefault();
+    if (!name.trim() || !content.trim()) {
+      toast({
+        title: t('Nome e comentário são obrigatórios.', 'Name and comment are required.'),
+      });
+      return;
+    }
+
+    addComment(
+      { postId, name, email, content },
+      {
+        onSuccess: () => {
+          toast({
+            title: t('Comentário enviado para aprovação!', 'Comment submitted for approval!'),
+          });
+          setName('');
+          setEmail('');
+          setContent('');
+        },
+        onError: () => {
+          toast({
+            title: t('Erro ao enviar comentário.', 'Error submitting comment.'),
+          });
+        },
+      }
+    );
+  };
+
+  return (
+    <section className="mt-12">
+      <h2 className="text-2xl font-semibold mb-4">
+        {t('Comentários', 'Comments')}
+      </h2>
+      {isLoading && (
+        <p>{t('Carregando comentários...', 'Loading comments...')}</p>
+      )}
+      {error && (
+        <p className="text-destructive">
+          {t('Erro ao carregar comentários.', 'Error loading comments.')}
+        </p>
+      )}
+      {!isLoading && !error && comments.length === 0 && (
+        <p>{t('Nenhum comentário ainda.', 'No comments yet.')}</p>
+      )}
+      <div className="space-y-4">
+        {comments.map((c) => (
+          <div key={c.id} className="border-b border-muted pb-2">
+            <p className="font-medium">{c.name}</p>
+            <p className="text-sm">{c.content}</p>
+          </div>
+        ))}
+      </div>
+      <form onSubmit={handleSubmit} className="mt-6 space-y-4">
+        <Input
+          placeholder={t('Seu nome', 'Your name')}
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+        />
+        <Input
+          type="email"
+          placeholder={t('Seu email (opcional)', 'Your email (optional)')}
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+        />
+        <Textarea
+          placeholder={t('Seu comentário', 'Your comment')}
+          value={content}
+          onChange={(e) => setContent(e.target.value)}
+        />
+        <Button type="submit">{t('Enviar', 'Submit')}</Button>
+      </form>
+    </section>
+  );
+}
+
+export default Comments;

--- a/src/components/__tests__/Comments.test.tsx
+++ b/src/components/__tests__/Comments.test.tsx
@@ -1,0 +1,59 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { LanguageProvider } from '@/hooks/useLanguage';
+import { Comments } from '../Comments';
+
+const addComment = vi.fn((_vars, opts?: any) => {
+  opts?.onSuccess?.();
+});
+
+vi.mock('@/hooks/useComments', () => ({
+  useComments: () => ({
+    comments: [],
+    isLoading: false,
+    error: null,
+    mutate: addComment,
+  }),
+}));
+
+const toastMock = vi.fn();
+vi.mock('@/components/ui/use-toast', () => ({
+  toast: (args: any) => toastMock(args),
+}));
+
+beforeEach(() => {
+  window.localStorage.setItem('lang', 'pt');
+  addComment.mockClear();
+  toastMock.mockClear();
+});
+
+describe('Comments component', () => {
+  it('submits a comment', async () => {
+    const user = userEvent.setup();
+    render(
+      <LanguageProvider>
+        <Comments postId="1" />
+      </LanguageProvider>
+    );
+
+    await user.type(screen.getByPlaceholderText(/seu nome/i), 'John');
+    await user.type(screen.getByPlaceholderText(/seu email/i), 'john@example.com');
+    await user.type(screen.getByPlaceholderText(/seu comentário/i), 'Olá');
+    await user.click(screen.getByRole('button', { name: /enviar/i }));
+
+    expect(addComment).toHaveBeenCalledWith(
+      {
+        postId: '1',
+        name: 'John',
+        email: 'john@example.com',
+        content: 'Olá',
+      },
+      expect.any(Object)
+    );
+    expect(screen.getByPlaceholderText(/seu nome/i)).toHaveValue('');
+    expect(screen.getByPlaceholderText(/seu email/i)).toHaveValue('');
+    expect(screen.getByPlaceholderText(/seu comentário/i)).toHaveValue('');
+    expect(toastMock).toHaveBeenCalled();
+  });
+});

--- a/src/pages/BlogPost.tsx
+++ b/src/pages/BlogPost.tsx
@@ -9,6 +9,7 @@ import { LoadingSkeleton } from '@/components/ui/loading-skeleton';
 import { ErrorState } from '@/components/ui/error-state';
 import { Card, CardContent } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
+import { Comments } from '@/components/Comments';
 
 export default function BlogPost() {
   const { slug } = useParams();
@@ -63,6 +64,7 @@ export default function BlogPost() {
                 <div dangerouslySetInnerHTML={{ __html: (language === 'pt' ? post.content_pt : (post.content_en || post.content_pt)) || '' }} />
               </CardContent>
             </Card>
+            <Comments postId={post.id} />
             <div className="mt-8">
               <Button variant="outline" asChild>
                 <Link to="/blog">{t('Voltar ao blog', 'Back to blog')}</Link>

--- a/tests/comments.spec.ts
+++ b/tests/comments.spec.ts
@@ -1,0 +1,57 @@
+import { test, expect } from '@playwright/test';
+
+const SUPABASE_URL = 'https://fineleshydmsyjcvffye.supabase.co';
+
+test('user can submit comment', async ({ page }) => {
+  await page.route(`${SUPABASE_URL}/rest/v1/blog_posts*`, route => {
+    if (route.request().method() === 'GET') {
+      route.fulfill({
+        status: 200,
+        body: JSON.stringify([
+          {
+            id: '1',
+            slug: 'test-slug',
+            title_pt: 'Título',
+            title_en: 'Title',
+            content_pt: '<p>conteúdo</p>',
+            content_en: '<p>content</p>',
+            published: true,
+            author: { name: 'Autor' }
+          }
+        ]),
+        headers: {
+          'content-type': 'application/json',
+          'content-range': '0-0/1'
+        }
+      });
+    }
+  });
+
+  await page.route(`${SUPABASE_URL}/rest/v1/comments*`, route => {
+    if (route.request().method() === 'GET') {
+      route.fulfill({
+        status: 200,
+        body: JSON.stringify([]),
+        headers: {
+          'content-type': 'application/json',
+          'content-range': '0-0/0'
+        }
+      });
+    } else if (route.request().method() === 'POST') {
+      route.fulfill({
+        status: 201,
+        body: JSON.stringify({}),
+        headers: {
+          'content-type': 'application/json'
+        }
+      });
+    }
+  });
+
+  await page.goto('/blog/test-slug');
+  await page.fill('input[placeholder="Seu nome"]', 'John');
+  await page.fill('input[placeholder="Seu email (opcional)"]', 'john@example.com');
+  await page.fill('textarea[placeholder="Seu comentário"]', 'Olá');
+  await page.click('button:has-text("Enviar")');
+  await expect(page.locator('input[placeholder="Seu nome"]')).toHaveValue('');
+});


### PR DESCRIPTION
## Summary
- add Comments component with basic validation and translations
- render comments section on blog posts
- test comment submission in unit and e2e suites

## Testing
- `./ci_test_local.sh`


------
https://chatgpt.com/codex/tasks/task_e_6898b672a74c8322ad308b076458c0a3