### PR TITLE
feat: show draft status in admin blog posts

### DIFF
--- a/src/components/ui/badge.tsx
+++ b/src/components/ui/badge.tsx
@@ -33,4 +33,5 @@ function Badge({ className, variant, ...props }: BadgeProps) {
   )
 }
 
-export { Badge, badgeVariants }
+export { Badge }
+export { badgeVariants } // eslint-disable-line react-refresh/only-export-components

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -59,4 +59,5 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
 )
 Button.displayName = "Button"
 
-export { Button, buttonVariants }
+export { Button }
+export { buttonVariants } // eslint-disable-line react-refresh/only-export-components

--- a/src/components/ui/form.tsx
+++ b/src/components/ui/form.tsx
@@ -165,7 +165,6 @@ const FormMessage = React.forwardRef<
 FormMessage.displayName = "FormMessage"
 
 export {
-  useFormField,
   Form,
   FormItem,
   FormLabel,
@@ -174,3 +173,4 @@ export {
   FormMessage,
   FormField,
 }
+export { useFormField } // eslint-disable-line react-refresh/only-export-components

--- a/src/components/ui/navigation-menu.tsx
+++ b/src/components/ui/navigation-menu.tsx
@@ -116,7 +116,6 @@ NavigationMenuIndicator.displayName =
   NavigationMenuPrimitive.Indicator.displayName
 
 export {
-  navigationMenuTriggerStyle,
   NavigationMenu,
   NavigationMenuList,
   NavigationMenuItem,
@@ -126,3 +125,4 @@ export {
   NavigationMenuIndicator,
   NavigationMenuViewport,
 }
+export { navigationMenuTriggerStyle } // eslint-disable-line react-refresh/only-export-components

--- a/src/components/ui/sidebar.tsx
+++ b/src/components/ui/sidebar.tsx
@@ -757,5 +757,5 @@ export {
   SidebarRail,
   SidebarSeparator,
   SidebarTrigger,
-  useSidebar,
 }
+export { useSidebar } // eslint-disable-line react-refresh/only-export-components

--- a/src/components/ui/sonner.tsx
+++ b/src/components/ui/sonner.tsx
@@ -26,4 +26,5 @@ const Toaster = ({ ...props }: ToasterProps) => {
   )
 }
 
-export { Toaster, toast }
+export { Toaster }
+export { toast } // eslint-disable-line react-refresh/only-export-components

--- a/src/components/ui/toggle.tsx
+++ b/src/components/ui/toggle.tsx
@@ -40,4 +40,5 @@ const Toggle = React.forwardRef<
 
 Toggle.displayName = TogglePrimitive.Root.displayName
 
-export { Toggle, toggleVariants }
+export { Toggle }
+export { toggleVariants } // eslint-disable-line react-refresh/only-export-components

--- a/src/hooks/useAllBlogPosts.ts
+++ b/src/hooks/useAllBlogPosts.ts
@@ -1,0 +1,34 @@
+import { useQuery } from '@tanstack/react-query';
+import { supabase } from '@/integrations/supabase/client';
+import type { Database } from '@/integrations/supabase/types';
+
+type BlogPost = Database['public']['Tables']['blog_posts']['Row'] & {
+  author: Database['public']['Tables']['authors']['Row'] | null;
+  categories: {
+    category: Database['public']['Tables']['categories']['Row'];
+  }[];
+};
+
+export function useAllBlogPosts() {
+  return useQuery<BlogPost[]>({
+    queryKey: ['all-blog-posts'],
+    queryFn: async () => {
+      const { data, error } = await supabase
+        .from('blog_posts')
+        .select(`
+          *,
+          author:authors(*),
+          categories:blog_posts_categories(
+            category:categories(*)
+          )
+        `)
+        .order('published_at', { ascending: false });
+
+      if (error) {
+        throw new Error(error.message);
+      }
+
+      return data as BlogPost[];
+    },
+  });
+}

--- a/src/hooks/useAuth.tsx
+++ b/src/hooks/useAuth.tsx
@@ -79,6 +79,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
   );
 }
 
+// eslint-disable-next-line react-refresh/only-export-components
 export function useAuth() {
   const context = useContext(AuthContext);
   if (context === undefined) {

--- a/src/hooks/useLanguage.tsx
+++ b/src/hooks/useLanguage.tsx
@@ -38,6 +38,7 @@ export function LanguageProvider({ children }: { children: ReactNode }) {
   );
 }
 
+// eslint-disable-next-line react-refresh/only-export-components
 export function useLanguage() {
   const context = useContext(LanguageContext);
   if (context === undefined) {

--- a/src/pages/admin/BlogPosts.test.tsx
+++ b/src/pages/admin/BlogPosts.test.tsx
@@ -1,0 +1,60 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, vi } from 'vitest';
+import BlogPosts from './BlogPosts';
+
+vi.mock('@/hooks/useAllBlogPosts', () => ({
+  useAllBlogPosts: () => ({
+    data: [
+      {
+        id: '1',
+        author_id: 'a1',
+        slug: 'post-1',
+        title_pt: 'Post 1',
+        title_en: 'Post 1 EN',
+        content_pt: 'Conteúdo',
+        content_en: 'Content',
+        published: true,
+        published_at: '2024-01-01',
+        author: { id: 'a1', name: 'Author One' },
+        categories: [],
+      },
+      {
+        id: '2',
+        author_id: 'a2',
+        slug: 'post-2',
+        title_pt: 'Draft Post',
+        title_en: 'Draft Post EN',
+        content_pt: 'Rascunho',
+        content_en: 'Draft',
+        published: false,
+        published_at: null,
+        author: { id: 'a2', name: 'Author Two' },
+        categories: [],
+      },
+    ],
+    isLoading: false,
+    error: null,
+    refetch: vi.fn(),
+  }),
+}));
+
+vi.mock('@/hooks/useAuthors', () => ({
+  useAuthors: () => ({
+    data: [
+      { id: 'a1', name: 'Author One' },
+      { id: 'a2', name: 'Author Two' },
+    ],
+  }),
+}));
+
+vi.mock('@/hooks/useCategories', () => ({
+  useCategories: () => ({ data: [] }),
+}));
+
+describe('Admin BlogPosts page', () => {
+  it('renders published and draft badges', () => {
+    render(<BlogPosts />);
+    expect(screen.getByText('Published')).toBeInTheDocument();
+    expect(screen.getByText('Draft')).toBeInTheDocument();
+  });
+});

--- a/src/pages/admin/BlogPosts.tsx
+++ b/src/pages/admin/BlogPosts.tsx
@@ -1,5 +1,4 @@
-import { useState } from 'react';
-import { useBlogPosts } from '@/hooks/useBlogPosts';
+import { useAllBlogPosts } from '@/hooks/useAllBlogPosts';
 import { useAuthors } from '@/hooks/useAuthors';
 import { useCategories } from '@/hooks/useCategories';
 import { Button } from '@/components/ui/button';
@@ -11,7 +10,7 @@ import { Plus, Edit, Trash2, Eye, Calendar, FileText } from 'lucide-react';
 import { format } from 'date-fns';
 
 export default function BlogPosts() {
-  const { data: posts, isLoading, error, refetch } = useBlogPosts();
+  const { data: posts, isLoading, error, refetch } = useAllBlogPosts();
   const { data: authors } = useAuthors();
   const { data: categories } = useCategories();
 


### PR DESCRIPTION
## Summary
- add `useAllBlogPosts` hook that fetches all posts
- show draft/published status in admin blog list
- add rendering test for admin blog posts page
- silence react-refresh warnings in shared hooks and UI components

## Testing
- `pnpm lint`
- `pnpm typecheck`
- `pnpm test`
- `pnpm test:e2e` *(fails: missing browsers)*

## Checklist
- [ ] Funcionalidade concluída e manual de teste incluído
- [ ] Testes: unit + component + e2e (verde)
- [ ] Migrations aplicáveis + RLS/Policies revisadas
- [ ] i18n cobrindo PT/EN (fallback ok)
- [ ] A11y básica (sem erros axe/lighthouse críticos)
- [ ] Desempenho dentro do budget
- [ ] Docs/README/CHANGELOG atualizados
- [ ] Sem segredos vazando; service key apenas server/CI
- [ ] Capturas de tela ou vídeo curto (quando visual)


------
https://chatgpt.com/codex/tasks/task_e_6898dbb18cc08322b05f0cb875cc6f26