### PR TITLE
feat: add admin CRUD forms

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -16,6 +16,12 @@ import EditPost from "./pages/admin/posts/EditPost";
 import Projects from "./pages/admin/Projects";
 import Authors from "./pages/admin/Authors";
 import Categories from "./pages/admin/Categories";
+import NewProject from "./pages/admin/projects/NewProject";
+import EditProject from "./pages/admin/projects/EditProject";
+import NewAuthor from "./pages/admin/authors/NewAuthor";
+import EditAuthor from "./pages/admin/authors/EditAuthor";
+import NewCategory from "./pages/admin/categories/NewCategory";
+import EditCategory from "./pages/admin/categories/EditCategory";
 import SearchResults from "./pages/SearchResults";
 import BlogIndex from "./pages/BlogIndex";
 import BlogPost from "./pages/BlogPost";
@@ -54,9 +60,21 @@ const App = () => (
                     <Route path="new" element={<NewPost />} />
                     <Route path=":id/edit" element={<EditPost />} />
                   </Route>
-                  <Route path="projects" element={<Projects />} />
-                  <Route path="authors" element={<Authors />} />
-                  <Route path="categories" element={<Categories />} />
+                  <Route path="projects">
+                    <Route index element={<Projects />} />
+                    <Route path="new" element={<NewProject />} />
+                    <Route path=":id/edit" element={<EditProject />} />
+                  </Route>
+                  <Route path="authors">
+                    <Route index element={<Authors />} />
+                    <Route path="new" element={<NewAuthor />} />
+                    <Route path=":id/edit" element={<EditAuthor />} />
+                  </Route>
+                  <Route path="categories">
+                    <Route index element={<Categories />} />
+                    <Route path="new" element={<NewCategory />} />
+                    <Route path=":id/edit" element={<EditCategory />} />
+                  </Route>
                 </Route>
                 <Route path="/500" element={<ServerError />} />
                 {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}

--- a/src/hooks/useAuthors.ts
+++ b/src/hooks/useAuthors.ts
@@ -1,8 +1,10 @@
-import { useQuery } from '@tanstack/react-query';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { supabase } from '@/integrations/supabase/client';
 
 export function useAuthors() {
-  return useQuery({
+  const queryClient = useQueryClient();
+
+  const authorsQuery = useQuery({
     queryKey: ['authors'],
     queryFn: async () => {
       const { data, error } = await supabase
@@ -17,4 +19,38 @@ export function useAuthors() {
       return data;
     },
   });
+
+  const createAuthor = useMutation({
+    mutationFn: async (values: any) => {
+      const { error } = await supabase.from('authors').insert(values);
+      if (error) throw new Error(error.message);
+    },
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ['authors'] }),
+  });
+
+  const updateAuthor = useMutation({
+    mutationFn: async ({ id, ...values }: any) => {
+      const { error } = await supabase
+        .from('authors')
+        .update(values)
+        .eq('id', id);
+      if (error) throw new Error(error.message);
+    },
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ['authors'] }),
+  });
+
+  const deleteAuthor = useMutation({
+    mutationFn: async (id: string) => {
+      const { error } = await supabase.from('authors').delete().eq('id', id);
+      if (error) throw new Error(error.message);
+    },
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ['authors'] }),
+  });
+
+  return {
+    ...authorsQuery,
+    createAuthor: createAuthor.mutateAsync,
+    updateAuthor: updateAuthor.mutateAsync,
+    deleteAuthor: deleteAuthor.mutateAsync,
+  };
 }

--- a/src/hooks/useCategories.ts
+++ b/src/hooks/useCategories.ts
@@ -1,8 +1,10 @@
-import { useQuery } from '@tanstack/react-query';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { supabase } from '@/integrations/supabase/client';
 
 export function useCategories() {
-  return useQuery({
+  const queryClient = useQueryClient();
+
+  const categoriesQuery = useQuery({
     queryKey: ['categories'],
     queryFn: async () => {
       const { data, error } = await supabase
@@ -17,4 +19,38 @@ export function useCategories() {
       return data;
     },
   });
+
+  const createCategory = useMutation({
+    mutationFn: async (values: any) => {
+      const { error } = await supabase.from('categories').insert(values);
+      if (error) throw new Error(error.message);
+    },
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ['categories'] }),
+  });
+
+  const updateCategory = useMutation({
+    mutationFn: async ({ id, ...values }: any) => {
+      const { error } = await supabase
+        .from('categories')
+        .update(values)
+        .eq('id', id);
+      if (error) throw new Error(error.message);
+    },
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ['categories'] }),
+  });
+
+  const deleteCategory = useMutation({
+    mutationFn: async (id: string) => {
+      const { error } = await supabase.from('categories').delete().eq('id', id);
+      if (error) throw new Error(error.message);
+    },
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ['categories'] }),
+  });
+
+  return {
+    ...categoriesQuery,
+    createCategory: createCategory.mutateAsync,
+    updateCategory: updateCategory.mutateAsync,
+    deleteCategory: deleteCategory.mutateAsync,
+  };
 }

--- a/src/hooks/useProjects.ts
+++ b/src/hooks/useProjects.ts
@@ -1,8 +1,10 @@
-import { useQuery } from '@tanstack/react-query';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { supabase } from '@/integrations/supabase/client';
 
 export function useProjects() {
-  return useQuery({
+  const queryClient = useQueryClient();
+
+  const projectsQuery = useQuery({
     queryKey: ['projects'],
     queryFn: async () => {
       const { data, error } = await supabase
@@ -17,4 +19,38 @@ export function useProjects() {
       return data;
     },
   });
+
+  const createProject = useMutation({
+    mutationFn: async (values: any) => {
+      const { error } = await supabase.from('projects').insert(values);
+      if (error) throw new Error(error.message);
+    },
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ['projects'] }),
+  });
+
+  const updateProject = useMutation({
+    mutationFn: async ({ id, ...values }: any) => {
+      const { error } = await supabase
+        .from('projects')
+        .update(values)
+        .eq('id', id);
+      if (error) throw new Error(error.message);
+    },
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ['projects'] }),
+  });
+
+  const deleteProject = useMutation({
+    mutationFn: async (id: string) => {
+      const { error } = await supabase.from('projects').delete().eq('id', id);
+      if (error) throw new Error(error.message);
+    },
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ['projects'] }),
+  });
+
+  return {
+    ...projectsQuery,
+    createProject: createProject.mutateAsync,
+    updateProject: updateProject.mutateAsync,
+    deleteProject: deleteProject.mutateAsync,
+  };
 }

--- a/src/pages/admin/Authors.tsx
+++ b/src/pages/admin/Authors.tsx
@@ -6,6 +6,7 @@ import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
 import { LoadingSkeleton } from '@/components/ui/loading-skeleton';
 import { ErrorState } from '@/components/ui/error-state';
 import { Plus, Edit, Trash2, ExternalLink, Users as UsersIcon } from 'lucide-react';
+import { Link } from 'react-router-dom';
 
 export default function Authors() {
   const { data: authors, isLoading, error, refetch } = useAuthors();
@@ -20,9 +21,11 @@ export default function Authors() {
           <h1 className="text-3xl font-bold gradient-text">Authors</h1>
           <p className="text-muted-foreground">Manage content creators and contributors</p>
         </div>
-        <Button className="glow-hover">
-          <Plus className="h-4 w-4 mr-2" />
-          New Author
+        <Button className="glow-hover" asChild>
+          <Link to="/admin/authors/new">
+            <Plus className="h-4 w-4 mr-2" />
+            New Author
+          </Link>
         </Button>
       </div>
 
@@ -43,8 +46,10 @@ export default function Authors() {
                 <CardTitle className="font-space-grotesk">{author.name}</CardTitle>
                 
                 <div className="flex items-center justify-center gap-2 pt-2">
-                  <Button variant="ghost" size="sm">
-                    <Edit className="h-4 w-4" />
+                  <Button variant="ghost" size="sm" asChild>
+                    <Link to={`/admin/authors/${author.id}/edit`}>
+                      <Edit className="h-4 w-4" />
+                    </Link>
                   </Button>
                   <Button variant="ghost" size="sm" className="text-destructive hover:text-destructive">
                     <Trash2 className="h-4 w-4" />

--- a/src/pages/admin/Categories.tsx
+++ b/src/pages/admin/Categories.tsx
@@ -6,6 +6,7 @@ import { Badge } from '@/components/ui/badge';
 import { LoadingSkeleton } from '@/components/ui/loading-skeleton';
 import { ErrorState } from '@/components/ui/error-state';
 import { Plus, Edit, Trash2, BookOpen } from 'lucide-react';
+import { Link } from 'react-router-dom';
 
 export default function Categories() {
   const { data: categories, isLoading, error, refetch } = useCategories();
@@ -20,9 +21,11 @@ export default function Categories() {
           <h1 className="text-3xl font-bold gradient-text">Categories</h1>
           <p className="text-muted-foreground">Organize your content with categories</p>
         </div>
-        <Button className="glow-hover">
-          <Plus className="h-4 w-4 mr-2" />
-          New Category
+        <Button className="glow-hover" asChild>
+          <Link to="/admin/categories/new">
+            <Plus className="h-4 w-4 mr-2" />
+            New Category
+          </Link>
         </Button>
       </div>
 
@@ -45,8 +48,10 @@ export default function Categories() {
                   </Badge>
                 </div>
                 <div className="flex items-center gap-2">
-                  <Button variant="ghost" size="sm">
-                    <Edit className="h-4 w-4" />
+                  <Button variant="ghost" size="sm" asChild>
+                    <Link to={`/admin/categories/${category.id}/edit`}>
+                      <Edit className="h-4 w-4" />
+                    </Link>
                   </Button>
                   <Button variant="ghost" size="sm" className="text-destructive hover:text-destructive">
                     <Trash2 className="h-4 w-4" />

--- a/src/pages/admin/Projects.tsx
+++ b/src/pages/admin/Projects.tsx
@@ -6,6 +6,7 @@ import { Badge } from '@/components/ui/badge';
 import { LoadingSkeleton } from '@/components/ui/loading-skeleton';
 import { ErrorState } from '@/components/ui/error-state';
 import { Plus, Edit, Trash2, Eye, ExternalLink, Github, FolderOpen } from 'lucide-react';
+import { Link } from 'react-router-dom';
 
 export default function Projects() {
   const { data: projects, isLoading, error, refetch } = useProjects();
@@ -20,9 +21,11 @@ export default function Projects() {
           <h1 className="text-3xl font-bold gradient-text">Projects</h1>
           <p className="text-muted-foreground">Manage your portfolio projects</p>
         </div>
-        <Button className="glow-hover">
-          <Plus className="h-4 w-4 mr-2" />
-          New Project
+        <Button className="glow-hover" asChild>
+          <Link to="/admin/projects/new">
+            <Plus className="h-4 w-4 mr-2" />
+            New Project
+          </Link>
         </Button>
       </div>
 
@@ -55,8 +58,10 @@ export default function Projects() {
                     <Button variant="ghost" size="sm">
                       <Eye className="h-4 w-4" />
                     </Button>
-                    <Button variant="ghost" size="sm">
-                      <Edit className="h-4 w-4" />
+                    <Button variant="ghost" size="sm" asChild>
+                      <Link to={`/admin/projects/${project.id}/edit`}>
+                        <Edit className="h-4 w-4" />
+                      </Link>
                     </Button>
                     <Button variant="ghost" size="sm" className="text-destructive hover:text-destructive">
                       <Trash2 className="h-4 w-4" />

--- a/src/pages/admin/authors/EditAuthor.test.tsx
+++ b/src/pages/admin/authors/EditAuthor.test.tsx
@@ -1,0 +1,51 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { describe, it, vi } from 'vitest';
+import EditAuthor from './EditAuthor';
+
+vi.stubGlobal('ResizeObserver', class {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+});
+
+const updateMock = vi.fn(() => ({ eq: () => Promise.resolve({ error: null }) }));
+const deleteMock = vi.fn(() => ({ eq: () => Promise.resolve({}) }));
+const fromMock = (table: string) => {
+  if (table === 'authors') {
+    return {
+      select: () => ({ eq: () => ({ single: () => Promise.resolve({ data: { id: '1', name: 'Old', bio: null, links: null, photo_url: null }, error: null }) }) }),
+      update: updateMock,
+      delete: deleteMock,
+    } as any;
+  }
+  return {} as any;
+};
+
+vi.mock('@/integrations/supabase/client', () => ({
+  supabase: {
+    from: (...args: any[]) => fromMock(...args),
+    storage: { from: () => ({ upload: vi.fn().mockResolvedValue({ data: {}, error: null }) }) },
+  },
+}));
+
+const navigateMock = vi.fn();
+vi.mock('react-router-dom', () => ({
+  useNavigate: () => navigateMock,
+  useParams: () => ({ id: '1' }),
+}));
+vi.mock('@tanstack/react-query', async () => {
+  const actual: any = await vi.importActual('@tanstack/react-query');
+  return { ...actual, useQueryClient: () => ({ invalidateQueries: vi.fn() }) };
+});
+
+describe('EditAuthor', () => {
+  it('loads and updates author', async () => {
+    render(<EditAuthor />);
+    const name = await screen.findByLabelText('Name');
+    expect(name).toHaveValue('Old');
+    fireEvent.change(name, { target: { value: 'New' } });
+    fireEvent.click(screen.getByRole('button', { name: /save/i }));
+    await waitFor(() => expect(updateMock).toHaveBeenCalled());
+    expect(navigateMock).toHaveBeenCalledWith('/admin/authors');
+  });
+});

--- a/src/pages/admin/authors/EditAuthor.tsx
+++ b/src/pages/admin/authors/EditAuthor.tsx
@@ -1,0 +1,172 @@
+import { useEffect, useState } from 'react';
+import { useForm } from 'react-hook-form';
+import { useNavigate, useParams } from 'react-router-dom';
+import { useQueryClient } from '@tanstack/react-query';
+import { supabase } from '@/integrations/supabase/client';
+import { toast } from '@/hooks/use-toast';
+import { Form, FormField, FormItem, FormLabel, FormControl, FormMessage } from '@/components/ui/form';
+import { Input } from '@/components/ui/input';
+import { Textarea } from '@/components/ui/textarea';
+import { Button } from '@/components/ui/button';
+
+interface FormValues {
+  name: string;
+  bio?: string;
+  links: string;
+  photo_url?: string;
+}
+
+export default function EditAuthor() {
+  const { id } = useParams<{ id: string }>();
+  const form = useForm<FormValues>({
+    defaultValues: {
+      name: '',
+      bio: '',
+      links: '',
+      photo_url: '',
+    },
+  });
+
+  const navigate = useNavigate();
+  const queryClient = useQueryClient();
+  const [loading, setLoading] = useState(true);
+  const [uploading, setUploading] = useState(false);
+
+  useEffect(() => {
+    const fetchAuthor = async () => {
+      const { data, error } = await supabase
+        .from('authors')
+        .select('*')
+        .eq('id', id)
+        .single();
+      if (error) {
+        toast({ title: 'Failed to load author', variant: 'destructive' });
+        return;
+      }
+      form.reset({
+        name: data.name,
+        bio: data.bio || '',
+        links: data.links ? JSON.stringify(data.links) : '',
+        photo_url: data.photo_url || '',
+      });
+      setLoading(false);
+    };
+    fetchAuthor();
+  }, [id, form]);
+
+  const handlePhotoUpload = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    try {
+      setUploading(true);
+      const filePath = `authors/${Date.now()}-${file.name}`;
+      const { error } = await supabase.storage.from('media').upload(filePath, file);
+      if (error) throw error;
+      form.setValue('photo_url', filePath);
+      toast({ title: 'Photo uploaded', description: filePath });
+    } catch {
+      toast({ title: 'Failed to upload photo', variant: 'destructive' });
+    } finally {
+      setUploading(false);
+    }
+  };
+
+  const onSubmit = async (values: FormValues) => {
+    try {
+      const links = values.links ? JSON.parse(values.links) : null;
+      const { error } = await supabase
+        .from('authors')
+        .update({
+          name: values.name,
+          bio: values.bio,
+          links,
+          photo_url: values.photo_url,
+        })
+        .eq('id', id);
+      if (error) throw error;
+      toast({ title: 'Author updated' });
+      queryClient.invalidateQueries({ queryKey: ['authors'] });
+      navigate('/admin/authors');
+    } catch {
+      toast({ title: 'Failed to update author', variant: 'destructive' });
+    }
+  };
+
+  const handleDelete = async () => {
+    try {
+      await supabase.from('authors').delete().eq('id', id);
+      toast({ title: 'Author deleted' });
+      queryClient.invalidateQueries({ queryKey: ['authors'] });
+      navigate('/admin/authors');
+    } catch {
+      toast({ title: 'Failed to delete author', variant: 'destructive' });
+    }
+  };
+
+  if (loading) return <div>Loading...</div>;
+
+  return (
+    <div className="max-w-xl mx-auto">
+      <div className="flex items-center justify-between mb-6">
+        <h1 className="text-3xl font-bold gradient-text">Edit Author</h1>
+        <Button variant="destructive" onClick={handleDelete} disabled={uploading}>
+          Delete
+        </Button>
+      </div>
+      <Form {...form}>
+        <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-6">
+          <FormField
+            control={form.control}
+            name="name"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Name</FormLabel>
+                <FormControl>
+                  <Input {...field} />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+
+          <FormField
+            control={form.control}
+            name="bio"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Bio</FormLabel>
+                <FormControl>
+                  <Textarea {...field} />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+
+          <FormField
+            control={form.control}
+            name="links"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Links (JSON)</FormLabel>
+                <FormControl>
+                  <Textarea {...field} />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+
+          <div>
+            <FormLabel>Photo</FormLabel>
+            <Input type="file" onChange={handlePhotoUpload} disabled={uploading} />
+          </div>
+
+          <Button type="submit" className="glow-hover" disabled={uploading}>
+            Save
+          </Button>
+        </form>
+      </Form>
+    </div>
+  );
+}

--- a/src/pages/admin/authors/NewAuthor.test.tsx
+++ b/src/pages/admin/authors/NewAuthor.test.tsx
@@ -1,0 +1,34 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { describe, it, vi } from 'vitest';
+import NewAuthor from './NewAuthor';
+
+vi.stubGlobal('ResizeObserver', class {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+});
+
+const insertAuthor = vi.fn(() => ({ error: null }));
+vi.mock('@/integrations/supabase/client', () => ({
+  supabase: {
+    from: (table: string) => ({ insert: insertAuthor }),
+    storage: { from: () => ({ upload: vi.fn().mockResolvedValue({ data: {}, error: null }) }) },
+  },
+}));
+
+const navigateMock = vi.fn();
+vi.mock('react-router-dom', () => ({ useNavigate: () => navigateMock }));
+vi.mock('@tanstack/react-query', async () => {
+  const actual: any = await vi.importActual('@tanstack/react-query');
+  return { ...actual, useQueryClient: () => ({ invalidateQueries: vi.fn() }) };
+});
+
+describe('NewAuthor', () => {
+  it('submits form', async () => {
+    render(<NewAuthor />);
+    fireEvent.change(screen.getByLabelText('Name'), { target: { value: 'Author' } });
+    fireEvent.click(screen.getByRole('button', { name: /save/i }));
+    await waitFor(() => expect(insertAuthor).toHaveBeenCalled());
+    expect(navigateMock).toHaveBeenCalledWith('/admin/authors');
+  });
+});

--- a/src/pages/admin/authors/NewAuthor.tsx
+++ b/src/pages/admin/authors/NewAuthor.tsx
@@ -1,0 +1,127 @@
+import { useState } from 'react';
+import { useForm } from 'react-hook-form';
+import { useNavigate } from 'react-router-dom';
+import { useQueryClient } from '@tanstack/react-query';
+import { supabase } from '@/integrations/supabase/client';
+import { toast } from '@/hooks/use-toast';
+import { Form, FormField, FormItem, FormLabel, FormControl, FormMessage } from '@/components/ui/form';
+import { Input } from '@/components/ui/input';
+import { Textarea } from '@/components/ui/textarea';
+import { Button } from '@/components/ui/button';
+
+interface FormValues {
+  name: string;
+  bio?: string;
+  links: string;
+  photo_url?: string;
+}
+
+export default function NewAuthor() {
+  const form = useForm<FormValues>({
+    defaultValues: {
+      name: '',
+      bio: '',
+      links: '',
+      photo_url: '',
+    },
+  });
+
+  const navigate = useNavigate();
+  const queryClient = useQueryClient();
+  const [uploading, setUploading] = useState(false);
+
+  const handlePhotoUpload = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    try {
+      setUploading(true);
+      const filePath = `authors/${Date.now()}-${file.name}`;
+      const { error } = await supabase.storage.from('media').upload(filePath, file);
+      if (error) throw error;
+      form.setValue('photo_url', filePath);
+      toast({ title: 'Photo uploaded', description: filePath });
+    } catch {
+      toast({ title: 'Failed to upload photo', variant: 'destructive' });
+    } finally {
+      setUploading(false);
+    }
+  };
+
+  const onSubmit = async (values: FormValues) => {
+    try {
+      const links = values.links ? JSON.parse(values.links) : null;
+      const { error } = await supabase.from('authors').insert({
+        name: values.name,
+        bio: values.bio,
+        links,
+        photo_url: values.photo_url,
+      });
+      if (error) throw error;
+      toast({ title: 'Author created' });
+      queryClient.invalidateQueries({ queryKey: ['authors'] });
+      navigate('/admin/authors');
+    } catch {
+      toast({ title: 'Failed to create author', variant: 'destructive' });
+    }
+  };
+
+  return (
+    <div className="max-w-xl mx-auto">
+      <h1 className="text-3xl font-bold mb-6 gradient-text">New Author</h1>
+      <Form {...form}>
+        <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-6">
+          <FormField
+            control={form.control}
+            name="name"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Name</FormLabel>
+                <FormControl>
+                  <Input {...field} />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+
+          <FormField
+            control={form.control}
+            name="bio"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Bio</FormLabel>
+                <FormControl>
+                  <Textarea {...field} />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+
+          <FormField
+            control={form.control}
+            name="links"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Links (JSON)</FormLabel>
+                <FormControl>
+                  <Textarea {...field} />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+
+          <div>
+            <FormLabel>Photo</FormLabel>
+            <Input type="file" onChange={handlePhotoUpload} disabled={uploading} />
+          </div>
+
+          <Button type="submit" className="glow-hover" disabled={uploading}>
+            Save
+          </Button>
+        </form>
+      </Form>
+    </div>
+  );
+}

--- a/src/pages/admin/categories/EditCategory.test.tsx
+++ b/src/pages/admin/categories/EditCategory.test.tsx
@@ -1,0 +1,50 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { describe, it, vi } from 'vitest';
+import EditCategory from './EditCategory';
+
+vi.stubGlobal('ResizeObserver', class {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+});
+
+const updateMock = vi.fn(() => ({ eq: () => Promise.resolve({ error: null }) }));
+const deleteMock = vi.fn(() => ({ eq: () => Promise.resolve({}) }));
+const fromMock = (table: string) => {
+  if (table === 'categories') {
+    return {
+      select: () => ({ eq: () => ({ single: () => Promise.resolve({ data: { id: '1', slug: 'old', title_pt: 'Old', title_en: null, description_pt: null, description_en: null }, error: null }) }) }),
+      update: updateMock,
+      delete: deleteMock,
+    } as any;
+  }
+  return {} as any;
+};
+
+vi.mock('@/integrations/supabase/client', () => ({
+  supabase: {
+    from: (...args: any[]) => fromMock(...args),
+  },
+}));
+
+const navigateMock = vi.fn();
+vi.mock('react-router-dom', () => ({
+  useNavigate: () => navigateMock,
+  useParams: () => ({ id: '1' }),
+}));
+vi.mock('@tanstack/react-query', async () => {
+  const actual: any = await vi.importActual('@tanstack/react-query');
+  return { ...actual, useQueryClient: () => ({ invalidateQueries: vi.fn() }) };
+});
+
+describe('EditCategory', () => {
+  it('loads and updates category', async () => {
+    render(<EditCategory />);
+    const title = await screen.findByLabelText('Title (PT)');
+    expect(title).toHaveValue('Old');
+    fireEvent.change(title, { target: { value: 'New' } });
+    fireEvent.click(screen.getByRole('button', { name: /save/i }));
+    await waitFor(() => expect(updateMock).toHaveBeenCalled());
+    expect(navigateMock).toHaveBeenCalledWith('/admin/categories');
+  });
+});

--- a/src/pages/admin/categories/EditCategory.tsx
+++ b/src/pages/admin/categories/EditCategory.tsx
@@ -1,0 +1,186 @@
+import { useEffect, useState } from 'react';
+import { useForm } from 'react-hook-form';
+import { useNavigate, useParams } from 'react-router-dom';
+import { useQueryClient } from '@tanstack/react-query';
+import { supabase } from '@/integrations/supabase/client';
+import { toast } from '@/hooks/use-toast';
+import { Form, FormField, FormItem, FormLabel, FormControl, FormMessage } from '@/components/ui/form';
+import { Input } from '@/components/ui/input';
+import { Textarea } from '@/components/ui/textarea';
+import { Button } from '@/components/ui/button';
+
+interface FormValues {
+  slug: string;
+  title_pt: string;
+  title_en?: string;
+  description_pt?: string;
+  description_en?: string;
+}
+
+const slugify = (text: string) =>
+  text
+    .toLowerCase()
+    .trim()
+    .replace(/[^\w\s-]/g, '')
+    .replace(/\s+/g, '-');
+
+export default function EditCategory() {
+  const { id } = useParams<{ id: string }>();
+  const form = useForm<FormValues>({
+    defaultValues: {
+      slug: '',
+      title_pt: '',
+      title_en: '',
+      description_pt: '',
+      description_en: '',
+    },
+  });
+
+  const navigate = useNavigate();
+  const queryClient = useQueryClient();
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const fetchCategory = async () => {
+      const { data, error } = await supabase
+        .from('categories')
+        .select('*')
+        .eq('id', id)
+        .single();
+      if (error) {
+        toast({ title: 'Failed to load category', variant: 'destructive' });
+        return;
+      }
+      form.reset({
+        slug: data.slug,
+        title_pt: data.title_pt,
+        title_en: data.title_en || '',
+        description_pt: data.description_pt || '',
+        description_en: data.description_en || '',
+      });
+      setLoading(false);
+    };
+    fetchCategory();
+  }, [id, form]);
+
+  const titleWatch = form.watch('title_pt');
+  useEffect(() => {
+    form.setValue('slug', slugify(titleWatch || ''));
+  }, [titleWatch, form]);
+
+  const onSubmit = async (values: FormValues) => {
+    try {
+      const { error } = await supabase
+        .from('categories')
+        .update(values)
+        .eq('id', id);
+      if (error) throw error;
+      toast({ title: 'Category updated' });
+      queryClient.invalidateQueries({ queryKey: ['categories'] });
+      navigate('/admin/categories');
+    } catch {
+      toast({ title: 'Failed to update category', variant: 'destructive' });
+    }
+  };
+
+  const handleDelete = async () => {
+    try {
+      await supabase.from('categories').delete().eq('id', id);
+      toast({ title: 'Category deleted' });
+      queryClient.invalidateQueries({ queryKey: ['categories'] });
+      navigate('/admin/categories');
+    } catch {
+      toast({ title: 'Failed to delete category', variant: 'destructive' });
+    }
+  };
+
+  if (loading) return <div>Loading...</div>;
+
+  return (
+    <div className="max-w-2xl mx-auto">
+      <div className="flex items-center justify-between mb-6">
+        <h1 className="text-3xl font-bold gradient-text">Edit Category</h1>
+        <Button variant="destructive" onClick={handleDelete}>
+          Delete
+        </Button>
+      </div>
+      <Form {...form}>
+        <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-6">
+          <FormField
+            control={form.control}
+            name="title_pt"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Title (PT)</FormLabel>
+                <FormControl>
+                  <Input {...field} />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+
+          <FormField
+            control={form.control}
+            name="title_en"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Title (EN)</FormLabel>
+                <FormControl>
+                  <Input {...field} />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+
+          <FormField
+            control={form.control}
+            name="slug"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Slug</FormLabel>
+                <FormControl>
+                  <Input {...field} readOnly />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+
+          <FormField
+            control={form.control}
+            name="description_pt"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Description (PT)</FormLabel>
+                <FormControl>
+                  <Textarea {...field} />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+
+          <FormField
+            control={form.control}
+            name="description_en"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Description (EN)</FormLabel>
+                <FormControl>
+                  <Textarea {...field} />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+
+          <Button type="submit" className="glow-hover">
+            Save
+          </Button>
+        </form>
+      </Form>
+    </div>
+  );
+}

--- a/src/pages/admin/categories/NewCategory.test.tsx
+++ b/src/pages/admin/categories/NewCategory.test.tsx
@@ -1,0 +1,34 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { describe, it, vi } from 'vitest';
+import NewCategory from './NewCategory';
+
+vi.stubGlobal('ResizeObserver', class {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+});
+
+const insertCategory = vi.fn(() => ({ error: null }));
+vi.mock('@/integrations/supabase/client', () => ({
+  supabase: {
+    from: (table: string) => ({ insert: insertCategory }),
+  },
+}));
+
+const navigateMock = vi.fn();
+vi.mock('react-router-dom', () => ({ useNavigate: () => navigateMock }));
+vi.mock('@tanstack/react-query', async () => {
+  const actual: any = await vi.importActual('@tanstack/react-query');
+  return { ...actual, useQueryClient: () => ({ invalidateQueries: vi.fn() }) };
+});
+
+describe('NewCategory', () => {
+  it('generates slug and submits', async () => {
+    render(<NewCategory />);
+    fireEvent.change(screen.getByLabelText('Title (PT)'), { target: { value: 'Tech News' } });
+    expect(screen.getByLabelText('Slug')).toHaveValue('tech-news');
+    fireEvent.click(screen.getByRole('button', { name: /save/i }));
+    await waitFor(() => expect(insertCategory).toHaveBeenCalled());
+    expect(navigateMock).toHaveBeenCalledWith('/admin/categories');
+  });
+});

--- a/src/pages/admin/categories/NewCategory.tsx
+++ b/src/pages/admin/categories/NewCategory.tsx
@@ -1,0 +1,140 @@
+import { useEffect } from 'react';
+import { useForm } from 'react-hook-form';
+import { useNavigate } from 'react-router-dom';
+import { useQueryClient } from '@tanstack/react-query';
+import { supabase } from '@/integrations/supabase/client';
+import { toast } from '@/hooks/use-toast';
+import { Form, FormField, FormItem, FormLabel, FormControl, FormMessage } from '@/components/ui/form';
+import { Input } from '@/components/ui/input';
+import { Textarea } from '@/components/ui/textarea';
+import { Button } from '@/components/ui/button';
+
+interface FormValues {
+  slug: string;
+  title_pt: string;
+  title_en?: string;
+  description_pt?: string;
+  description_en?: string;
+}
+
+const slugify = (text: string) =>
+  text
+    .toLowerCase()
+    .trim()
+    .replace(/[^\w\s-]/g, '')
+    .replace(/\s+/g, '-');
+
+export default function NewCategory() {
+  const form = useForm<FormValues>({
+    defaultValues: {
+      slug: '',
+      title_pt: '',
+      title_en: '',
+      description_pt: '',
+      description_en: '',
+    },
+  });
+
+  const navigate = useNavigate();
+  const queryClient = useQueryClient();
+
+  const titleWatch = form.watch('title_pt');
+  useEffect(() => {
+    form.setValue('slug', slugify(titleWatch || ''));
+  }, [titleWatch, form]);
+
+  const onSubmit = async (values: FormValues) => {
+    try {
+      const { error } = await supabase.from('categories').insert(values);
+      if (error) throw error;
+      toast({ title: 'Category created' });
+      queryClient.invalidateQueries({ queryKey: ['categories'] });
+      navigate('/admin/categories');
+    } catch {
+      toast({ title: 'Failed to create category', variant: 'destructive' });
+    }
+  };
+
+  return (
+    <div className="max-w-2xl mx-auto">
+      <h1 className="text-3xl font-bold mb-6 gradient-text">New Category</h1>
+      <Form {...form}>
+        <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-6">
+          <FormField
+            control={form.control}
+            name="title_pt"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Title (PT)</FormLabel>
+                <FormControl>
+                  <Input {...field} />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+
+          <FormField
+            control={form.control}
+            name="title_en"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Title (EN)</FormLabel>
+                <FormControl>
+                  <Input {...field} />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+
+          <FormField
+            control={form.control}
+            name="slug"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Slug</FormLabel>
+                <FormControl>
+                  <Input {...field} readOnly />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+
+          <FormField
+            control={form.control}
+            name="description_pt"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Description (PT)</FormLabel>
+                <FormControl>
+                  <Textarea {...field} />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+
+          <FormField
+            control={form.control}
+            name="description_en"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Description (EN)</FormLabel>
+                <FormControl>
+                  <Textarea {...field} />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+
+          <Button type="submit" className="glow-hover">
+            Save
+          </Button>
+        </form>
+      </Form>
+    </div>
+  );
+}

--- a/src/pages/admin/projects/EditProject.test.tsx
+++ b/src/pages/admin/projects/EditProject.test.tsx
@@ -1,0 +1,53 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { describe, it, vi } from 'vitest';
+import EditProject from './EditProject';
+
+vi.stubGlobal('ResizeObserver', class {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+});
+
+const updateMock = vi.fn(() => ({ eq: () => Promise.resolve({ error: null }) }));
+const deleteMock = vi.fn(() => ({ eq: () => Promise.resolve({}) }));
+const fromMock = (table: string) => {
+  if (table === 'projects') {
+    return {
+      select: () => ({
+        eq: () => ({ single: () => Promise.resolve({ data: { id: '1', slug: 'old', name_pt: 'Old', name_en: null, description_pt: null, description_en: null, links: null, icon: null }, error: null }) })
+      }),
+      update: updateMock,
+      delete: deleteMock,
+    } as any;
+  }
+  return {} as any;
+};
+
+vi.mock('@/integrations/supabase/client', () => ({
+  supabase: {
+    from: (...args: any[]) => fromMock(...args),
+    storage: { from: () => ({ upload: vi.fn().mockResolvedValue({ data: {}, error: null }) }) },
+  },
+}));
+
+const navigateMock = vi.fn();
+vi.mock('react-router-dom', () => ({
+  useNavigate: () => navigateMock,
+  useParams: () => ({ id: '1' }),
+}));
+vi.mock('@tanstack/react-query', async () => {
+  const actual: any = await vi.importActual('@tanstack/react-query');
+  return { ...actual, useQueryClient: () => ({ invalidateQueries: vi.fn() }) };
+});
+
+describe('EditProject', () => {
+  it('loads and updates project', async () => {
+    render(<EditProject />);
+    const name = await screen.findByLabelText('Name (PT)');
+    expect(name).toHaveValue('Old');
+    fireEvent.change(name, { target: { value: 'New' } });
+    fireEvent.click(screen.getByRole('button', { name: /save/i }));
+    await waitFor(() => expect(updateMock).toHaveBeenCalled());
+    expect(navigateMock).toHaveBeenCalledWith('/admin/projects');
+  });
+});

--- a/src/pages/admin/projects/EditProject.tsx
+++ b/src/pages/admin/projects/EditProject.tsx
@@ -1,0 +1,238 @@
+import { useEffect, useState } from 'react';
+import { useForm } from 'react-hook-form';
+import { useNavigate, useParams } from 'react-router-dom';
+import { useQueryClient } from '@tanstack/react-query';
+import { supabase } from '@/integrations/supabase/client';
+import { toast } from '@/hooks/use-toast';
+import { Form, FormField, FormItem, FormLabel, FormControl, FormMessage } from '@/components/ui/form';
+import { Input } from '@/components/ui/input';
+import { Textarea } from '@/components/ui/textarea';
+import { Button } from '@/components/ui/button';
+
+interface FormValues {
+  slug: string;
+  name_pt: string;
+  name_en?: string;
+  description_pt?: string;
+  description_en?: string;
+  links: string;
+  icon?: string;
+}
+
+const slugify = (text: string) =>
+  text
+    .toLowerCase()
+    .trim()
+    .replace(/[^\w\s-]/g, '')
+    .replace(/\s+/g, '-');
+
+export default function EditProject() {
+  const { id } = useParams<{ id: string }>();
+  const form = useForm<FormValues>({
+    defaultValues: {
+      slug: '',
+      name_pt: '',
+      name_en: '',
+      description_pt: '',
+      description_en: '',
+      links: '',
+      icon: '',
+    },
+  });
+
+  const navigate = useNavigate();
+  const queryClient = useQueryClient();
+  const [loading, setLoading] = useState(true);
+  const [uploading, setUploading] = useState(false);
+
+  useEffect(() => {
+    const fetchProject = async () => {
+      const { data, error } = await supabase
+        .from('projects')
+        .select('*')
+        .eq('id', id)
+        .single();
+      if (error) {
+        toast({ title: 'Failed to load project', variant: 'destructive' });
+        return;
+      }
+      form.reset({
+        slug: data.slug,
+        name_pt: data.name_pt,
+        name_en: data.name_en || '',
+        description_pt: data.description_pt || '',
+        description_en: data.description_en || '',
+        links: data.links ? JSON.stringify(data.links) : '',
+        icon: data.icon || '',
+      });
+      setLoading(false);
+    };
+    fetchProject();
+  }, [id, form]);
+
+  const nameWatch = form.watch('name_pt');
+  useEffect(() => {
+    form.setValue('slug', slugify(nameWatch || ''));
+  }, [nameWatch, form]);
+
+  const handleIconUpload = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    try {
+      setUploading(true);
+      const filePath = `projects/${Date.now()}-${file.name}`;
+      const { error } = await supabase.storage.from('media').upload(filePath, file);
+      if (error) throw error;
+      form.setValue('icon', filePath);
+      toast({ title: 'Icon uploaded', description: filePath });
+    } catch {
+      toast({ title: 'Failed to upload icon', variant: 'destructive' });
+    } finally {
+      setUploading(false);
+    }
+  };
+
+  const onSubmit = async (values: FormValues) => {
+    try {
+      const links = values.links ? JSON.parse(values.links) : null;
+      const { error } = await supabase
+        .from('projects')
+        .update({
+          slug: values.slug,
+          name_pt: values.name_pt,
+          name_en: values.name_en,
+          description_pt: values.description_pt,
+          description_en: values.description_en,
+          links,
+          icon: values.icon,
+        })
+        .eq('id', id);
+      if (error) throw error;
+      toast({ title: 'Project updated' });
+      queryClient.invalidateQueries({ queryKey: ['projects'] });
+      navigate('/admin/projects');
+    } catch {
+      toast({ title: 'Failed to update project', variant: 'destructive' });
+    }
+  };
+
+  const handleDelete = async () => {
+    try {
+      await supabase.from('projects').delete().eq('id', id);
+      toast({ title: 'Project deleted' });
+      queryClient.invalidateQueries({ queryKey: ['projects'] });
+      navigate('/admin/projects');
+    } catch {
+      toast({ title: 'Failed to delete project', variant: 'destructive' });
+    }
+  };
+
+  if (loading) return <div>Loading...</div>;
+
+  return (
+    <div className="max-w-2xl mx-auto">
+      <div className="flex items-center justify-between mb-6">
+        <h1 className="text-3xl font-bold gradient-text">Edit Project</h1>
+        <Button variant="destructive" onClick={handleDelete} disabled={uploading}>
+          Delete
+        </Button>
+      </div>
+      <Form {...form}>
+        <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-6">
+          <FormField
+            control={form.control}
+            name="name_pt"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Name (PT)</FormLabel>
+                <FormControl>
+                  <Input {...field} />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+
+          <FormField
+            control={form.control}
+            name="name_en"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Name (EN)</FormLabel>
+                <FormControl>
+                  <Input {...field} />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+
+          <FormField
+            control={form.control}
+            name="slug"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Slug</FormLabel>
+                <FormControl>
+                  <Input {...field} readOnly />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+
+          <FormField
+            control={form.control}
+            name="description_pt"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Description (PT)</FormLabel>
+                <FormControl>
+                  <Textarea {...field} />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+
+          <FormField
+            control={form.control}
+            name="description_en"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Description (EN)</FormLabel>
+                <FormControl>
+                  <Textarea {...field} />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+
+          <FormField
+            control={form.control}
+            name="links"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Links (JSON)</FormLabel>
+                <FormControl>
+                  <Textarea {...field} />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+
+          <div>
+            <FormLabel>Icon</FormLabel>
+            <Input type="file" onChange={handleIconUpload} disabled={uploading} />
+          </div>
+
+          <Button type="submit" className="glow-hover" disabled={uploading}>
+            Save
+          </Button>
+        </form>
+      </Form>
+    </div>
+  );
+}

--- a/src/pages/admin/projects/NewProject.test.tsx
+++ b/src/pages/admin/projects/NewProject.test.tsx
@@ -1,0 +1,35 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { describe, it, vi } from 'vitest';
+import NewProject from './NewProject';
+
+vi.stubGlobal('ResizeObserver', class {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+});
+
+const insertProject = vi.fn(() => ({ error: null }));
+vi.mock('@/integrations/supabase/client', () => ({
+  supabase: {
+    from: (table: string) => ({ insert: insertProject }),
+    storage: { from: () => ({ upload: vi.fn().mockResolvedValue({ data: {}, error: null }) }) },
+  },
+}));
+
+const navigateMock = vi.fn();
+vi.mock('react-router-dom', () => ({ useNavigate: () => navigateMock }));
+vi.mock('@tanstack/react-query', async () => {
+  const actual: any = await vi.importActual('@tanstack/react-query');
+  return { ...actual, useQueryClient: () => ({ invalidateQueries: vi.fn() }) };
+});
+
+describe('NewProject', () => {
+  it('generates slug and submits', async () => {
+    render(<NewProject />);
+    fireEvent.change(screen.getByLabelText('Name (PT)'), { target: { value: 'My Project' } });
+    expect(screen.getByLabelText('Slug')).toHaveValue('my-project');
+    fireEvent.click(screen.getByRole('button', { name: /save/i }));
+    await waitFor(() => expect(insertProject).toHaveBeenCalled());
+    expect(navigateMock).toHaveBeenCalledWith('/admin/projects');
+  });
+});

--- a/src/pages/admin/projects/NewProject.tsx
+++ b/src/pages/admin/projects/NewProject.tsx
@@ -1,0 +1,190 @@
+import { useEffect, useState } from 'react';
+import { useForm } from 'react-hook-form';
+import { useNavigate } from 'react-router-dom';
+import { useQueryClient } from '@tanstack/react-query';
+import { supabase } from '@/integrations/supabase/client';
+import { toast } from '@/hooks/use-toast';
+import { Form, FormField, FormItem, FormLabel, FormControl, FormMessage } from '@/components/ui/form';
+import { Input } from '@/components/ui/input';
+import { Textarea } from '@/components/ui/textarea';
+import { Button } from '@/components/ui/button';
+
+interface FormValues {
+  slug: string;
+  name_pt: string;
+  name_en?: string;
+  description_pt?: string;
+  description_en?: string;
+  links: string;
+  icon?: string;
+}
+
+const slugify = (text: string) =>
+  text
+    .toLowerCase()
+    .trim()
+    .replace(/[^\w\s-]/g, '')
+    .replace(/\s+/g, '-');
+
+export default function NewProject() {
+  const form = useForm<FormValues>({
+    defaultValues: {
+      slug: '',
+      name_pt: '',
+      name_en: '',
+      description_pt: '',
+      description_en: '',
+      links: '',
+      icon: '',
+    },
+  });
+
+  const navigate = useNavigate();
+  const queryClient = useQueryClient();
+  const [uploading, setUploading] = useState(false);
+
+  const nameWatch = form.watch('name_pt');
+  useEffect(() => {
+    form.setValue('slug', slugify(nameWatch || ''));
+  }, [nameWatch, form]);
+
+  const handleIconUpload = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    try {
+      setUploading(true);
+      const filePath = `projects/${Date.now()}-${file.name}`;
+      const { error } = await supabase.storage.from('media').upload(filePath, file);
+      if (error) throw error;
+      form.setValue('icon', filePath);
+      toast({ title: 'Icon uploaded', description: filePath });
+    } catch {
+      toast({ title: 'Failed to upload icon', variant: 'destructive' });
+    } finally {
+      setUploading(false);
+    }
+  };
+
+  const onSubmit = async (values: FormValues) => {
+    try {
+      const links = values.links ? JSON.parse(values.links) : null;
+      const { error } = await supabase.from('projects').insert({
+        slug: values.slug,
+        name_pt: values.name_pt,
+        name_en: values.name_en,
+        description_pt: values.description_pt,
+        description_en: values.description_en,
+        links,
+        icon: values.icon,
+      });
+      if (error) throw error;
+      toast({ title: 'Project created' });
+      queryClient.invalidateQueries({ queryKey: ['projects'] });
+      navigate('/admin/projects');
+    } catch {
+      toast({ title: 'Failed to create project', variant: 'destructive' });
+    }
+  };
+
+  return (
+    <div className="max-w-2xl mx-auto">
+      <h1 className="text-3xl font-bold mb-6 gradient-text">New Project</h1>
+      <Form {...form}>
+        <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-6">
+          <FormField
+            control={form.control}
+            name="name_pt"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Name (PT)</FormLabel>
+                <FormControl>
+                  <Input {...field} />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+
+          <FormField
+            control={form.control}
+            name="name_en"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Name (EN)</FormLabel>
+                <FormControl>
+                  <Input {...field} />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+
+          <FormField
+            control={form.control}
+            name="slug"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Slug</FormLabel>
+                <FormControl>
+                  <Input {...field} readOnly />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+
+          <FormField
+            control={form.control}
+            name="description_pt"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Description (PT)</FormLabel>
+                <FormControl>
+                  <Textarea {...field} />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+
+          <FormField
+            control={form.control}
+            name="description_en"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Description (EN)</FormLabel>
+                <FormControl>
+                  <Textarea {...field} />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+
+          <FormField
+            control={form.control}
+            name="links"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Links (JSON)</FormLabel>
+                <FormControl>
+                  <Textarea {...field} />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+
+          <div>
+            <FormLabel>Icon</FormLabel>
+            <Input type="file" onChange={handleIconUpload} disabled={uploading} />
+          </div>
+
+          <Button type="submit" className="glow-hover" disabled={uploading}>
+            Save
+          </Button>
+        </form>
+      </Form>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add admin forms for projects, authors and categories with slugging, links json and media uploads
- extend project, author and category hooks with create/update/delete helpers
- wire new routes and navigation for admin pages

## Testing
- `pnpm test`
- `./ci_test_local.sh` *(fails: Process from config.webServer exited early)*

------
https://chatgpt.com/codex/tasks/task_e_6898f3c21eb883229a2e0896f0e6ee34