### PR TITLE
feat: add i18n support and language switch test

### DIFF
--- a/src/components/About.tsx
+++ b/src/components/About.tsx
@@ -1,71 +1,112 @@
 import { Heart, Sparkles, Zap, Users, Globe, Code2 } from "lucide-react";
+import { useLanguage } from "@/hooks/useLanguage";
 
 const values = [
   {
     icon: Heart,
-    title: "Inclusão & Diversidade",
-    description: "Criamos tecnologia para todas as pessoas, celebrando a diversidade como nossa maior força.",
+    title: {
+      pt: "Inclusão & Diversidade",
+      en: "Inclusion & Diversity"
+    },
+    description: {
+      pt: "Criamos tecnologia para todas as pessoas, celebrando a diversidade como nossa maior força.",
+      en: "We create technology for everyone, celebrating diversity as our greatest strength."
+    },
     color: "text-pink-400"
   },
   {
     icon: Sparkles,
-    title: "Inovação Constante",
-    description: "Exploramos tecnologias emergentes para criar soluções que transcendem o presente.",
+    title: {
+      pt: "Inovação Constante",
+      en: "Constant Innovation"
+    },
+    description: {
+      pt: "Exploramos tecnologias emergentes para criar soluções que transcendem o presente.",
+      en: "We explore emerging technologies to craft solutions that transcend the present."
+    },
     color: "text-primary"
   },
   {
     icon: Zap,
-    title: "Performance Extrema",
-    description: "Otimizamos cada linha de código para entregar experiências instantâneas e fluidas.",
+    title: {
+      pt: "Performance Extrema",
+      en: "Extreme Performance"
+    },
+    description: {
+      pt: "Otimizamos cada linha de código para entregar experiências instantâneas e fluidas.",
+      en: "We optimize every line of code to deliver instant and smooth experiences."
+    },
     color: "text-secondary"
   },
   {
     icon: Users,
-    title: "Comunidade Ativa",
-    description: "Construímos juntos, compartilhamos conhecimento e crescemos como coletivo.",
+    title: {
+      pt: "Comunidade Ativa",
+      en: "Active Community"
+    },
+    description: {
+      pt: "Construímos juntos, compartilhamos conhecimento e crescemos como coletivo.",
+      en: "We build together, share knowledge, and grow as a collective."
+    },
     color: "text-purple-400"
   },
   {
     icon: Globe,
-    title: "Impacto Global",
-    description: "Nossas soluções conectam culturas e transformam vidas ao redor do mundo.",
+    title: {
+      pt: "Impacto Global",
+      en: "Global Impact"
+    },
+    description: {
+      pt: "Nossas soluções conectam culturas e transformam vidas ao redor do mundo.",
+      en: "Our solutions connect cultures and transform lives around the world."
+    },
     color: "text-green-400"
   },
   {
     icon: Code2,
-    title: "Open Source",
-    description: "Acreditamos no poder do código aberto para democratizar a tecnologia.",
+    title: {
+      pt: "Open Source",
+      en: "Open Source"
+    },
+    description: {
+      pt: "Acreditamos no poder do código aberto para democratizar a tecnologia.",
+      en: "We believe in the power of open source to democratize technology."
+    },
     color: "text-cyan-400"
   }
 ];
 
 const stats = [
-  { label: "Projetos Ativos", value: "50+", suffix: "" },
-  { label: "Contribuidores", value: "200+", suffix: "" },
-  { label: "Países Alcançados", value: "25+", suffix: "" },
-  { label: "Stars no GitHub", value: "15k+", suffix: "" }
+  { label: { pt: "Projetos Ativos", en: "Active Projects" }, value: "50+", suffix: "" },
+  { label: { pt: "Contribuidores", en: "Contributors" }, value: "200+", suffix: "" },
+  { label: { pt: "Países Alcançados", en: "Countries Reached" }, value: "25+", suffix: "" },
+  { label: { pt: "Stars no GitHub", en: "GitHub Stars" }, value: "15k+", suffix: "" }
 ];
 
 export function About() {
+  const { t } = useLanguage();
   return (
     <section className="py-20 relative">
       <div className="container mx-auto px-6">
         {/* Section Header */}
         <div className="text-center mb-16 animate-fade-in">
           <h2 className="text-5xl font-space-grotesk font-bold mb-6">
-            Sobre a <span className="gradient-text">Monynha</span>
+            {t("Sobre a", "About")}{" "}
+            <span className="gradient-text">Monynha</span>
           </h2>
           <p className="text-xl text-muted-foreground max-w-4xl mx-auto leading-relaxed">
-            Somos uma comunidade de desenvolvedores apaixonados por criar o futuro da web. 
-            Nascemos da necessidade de tecnologia mais inclusiva, acessível e extraordinária.
+            {t(
+              "Somos uma comunidade de desenvolvedores apaixonados por criar o futuro da web. Nascemos da necessidade de tecnologia mais inclusiva, acessível e extraordinária.",
+              "We are a community of developers passionate about building the future of the web. We were born from the need for more inclusive, accessible, and extraordinary technology."
+            )}
           </p>
         </div>
 
         {/* Stats */}
         <div className="grid grid-cols-2 md:grid-cols-4 gap-8 mb-20">
           {stats.map((stat, index) => (
-            <div 
-              key={stat.label} 
+            <div
+              key={stat.label.pt}
               className="text-center glass-card"
               style={{ animationDelay: `${index * 0.1}s` }}
             >
@@ -73,7 +114,7 @@ export function About() {
                 {stat.value}
               </div>
               <div className="text-muted-foreground font-medium">
-                {stat.label}
+                {t(stat.label.pt, stat.label.en)}
               </div>
             </div>
           ))}
@@ -84,8 +125,8 @@ export function About() {
           {values.map((value, index) => {
             const IconComponent = value.icon;
             return (
-              <div 
-                key={value.title} 
+              <div
+                key={value.title.pt}
                 className="glass-card glow-hover group"
                 style={{ animationDelay: `${index * 0.15}s` }}
               >
@@ -95,10 +136,10 @@ export function About() {
                   </div>
                   <div className="flex-1">
                     <h3 className="text-xl font-space-grotesk font-semibold mb-3 group-hover:gradient-text transition-all">
-                      {value.title}
+                      {t(value.title.pt, value.title.en)}
                     </h3>
                     <p className="text-muted-foreground leading-relaxed">
-                      {value.description}
+                      {t(value.description.pt, value.description.en)}
                     </p>
                   </div>
                 </div>
@@ -112,13 +153,13 @@ export function About() {
           <div className="glass-card max-w-4xl mx-auto">
             <div className="text-6xl mb-6">🏳️‍🌈</div>
             <h3 className="text-3xl font-space-grotesk font-bold mb-6 gradient-text">
-              Nossa Missão
+              {t("Nossa Missão", "Our Mission")}
             </h3>
             <p className="text-lg text-muted-foreground leading-relaxed">
-              Democratizar a tecnologia através de soluções inovadoras e inclusivas, 
-              criando um futuro digital onde todas as pessoas possam prosperar. 
-              Utilizamos nosso conhecimento técnico como ferramenta de transformação social, 
-              sempre celebrando a diversidade e promovendo a igualdade.
+              {t(
+                "Democratizar a tecnologia através de soluções inovadoras e inclusivas, criando um futuro digital onde todas as pessoas possam prosperar. Utilizamos nosso conhecimento técnico como ferramenta de transformação social, sempre celebrando a diversidade e promovendo a igualdade.",
+                "Democratize technology through innovative and inclusive solutions, creating a digital future where everyone can thrive. We use our technical knowledge as a tool for social transformation, always celebrating diversity and promoting equality."
+              )}
             </p>
           </div>
         </div>

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,8 +1,10 @@
 import { Button } from "@/components/ui/button";
 import { Github, Twitter, Linkedin, Mail, Heart, Code2 } from "lucide-react";
 import { Link } from "react-router-dom";
+import { useLanguage } from "@/hooks/useLanguage";
 
 export function Footer() {
+  const { t } = useLanguage();
   return (
     <footer className="relative py-20 border-t border-border/50">
       {/* Background Gradient */}
@@ -20,12 +22,16 @@ export function Footer() {
                 <h3 className="text-2xl font-space-grotesk font-bold gradient-text">
                   Monynha Softwares
                 </h3>
-                <p className="text-sm text-muted-foreground">Futuristic Development</p>
+                <p className="text-sm text-muted-foreground">
+                  {t("Desenvolvimento Futurista", "Futuristic Development")}
+                </p>
               </div>
             </div>
             <p className="text-muted-foreground leading-relaxed mb-6 max-w-lg">
-              Criamos experiências digitais futuristas e inclusivas. 
-              Nossa missão é democratizar a tecnologia e construir um futuro mais diverso e igualitário.
+              {t(
+                "Criamos experiências digitais futuristas e inclusivas. Nossa missão é democratizar a tecnologia e construir um futuro mais diverso e igualitário.",
+                "We create futuristic and inclusive digital experiences. Our mission is to democratize technology and build a more diverse and equal future."
+              )}
             </p>
             <div className="flex space-x-4">
               <Button variant="glass" size="icon">
@@ -45,25 +51,89 @@ export function Footer() {
 
           {/* Quick Links */}
           <div>
-            <h4 className="text-lg font-space-grotesk font-semibold mb-6">Navegação</h4>
+            <h4 className="text-lg font-space-grotesk font-semibold mb-6">
+              {t("Navegação", "Navigation")}
+            </h4>
             <ul className="space-y-3">
-              <li><Link to="/" className="text-muted-foreground hover:text-primary transition-colors">Início</Link></li>
-              <li><Link to="/projects" className="text-muted-foreground hover:text-primary transition-colors">Projetos</Link></li>
-              <li><Link to="/docs" className="text-muted-foreground hover:text-primary transition-colors">Documentação</Link></li>
-              <li><Link to="/blog" className="text-muted-foreground hover:text-primary transition-colors">Blog</Link></li>
-              <li><a href="/" className="text-muted-foreground hover:text-primary transition-colors">Comunidade</a></li>
+              <li>
+                <Link to="/" className="text-muted-foreground hover:text-primary transition-colors">
+                  {t("Início", "Home")}
+                </Link>
+              </li>
+              <li>
+                <Link to="/projects" className="text-muted-foreground hover:text-primary transition-colors">
+                  {t("Projetos", "Projects")}
+                </Link>
+              </li>
+              <li>
+                <Link to="/docs" className="text-muted-foreground hover:text-primary transition-colors">
+                  {t("Documentação", "Documentation")}
+                </Link>
+              </li>
+              <li>
+                <Link to="/blog" className="text-muted-foreground hover:text-primary transition-colors">
+                  {t("Blog", "Blog")}
+                </Link>
+              </li>
+              <li>
+                <a href="/" className="text-muted-foreground hover:text-primary transition-colors">
+                  {t("Comunidade", "Community")}
+                </a>
+              </li>
             </ul>
           </div>
 
           {/* Resources */}
           <div>
-            <h4 className="text-lg font-space-grotesk font-semibold mb-6">Recursos</h4>
+            <h4 className="text-lg font-space-grotesk font-semibold mb-6">
+              {t("Recursos", "Resources")}
+            </h4>
             <ul className="space-y-3">
-              <li><Link to="/docs" className="text-muted-foreground hover:text-primary transition-colors">API Docs</Link></li>
-              <li><a href="https://twitter.com" target="_blank" rel="noreferrer" className="text-muted-foreground hover:text-primary transition-colors">GitHub</a></li>
-              <li><a href="https://github.com" target="_blank" rel="noreferrer" className="text-muted-foreground hover:text-primary transition-colors">Contribuir</a></li>
-              <li><a href="https://github.com/roadmap" target="_blank" rel="noreferrer" className="text-muted-foreground hover:text-primary transition-colors">Roadmap</a></li>
-              <li><a href="https://www.githubstatus.com/" target="_blank" rel="noreferrer" className="text-muted-foreground hover:text-primary transition-colors">Status</a></li>
+              <li>
+                <Link to="/docs" className="text-muted-foreground hover:text-primary transition-colors">
+                  {t("API Docs", "API Docs")}
+                </Link>
+              </li>
+              <li>
+                <a
+                  href="https://twitter.com"
+                  target="_blank"
+                  rel="noreferrer"
+                  className="text-muted-foreground hover:text-primary transition-colors"
+                >
+                  GitHub
+                </a>
+              </li>
+              <li>
+                <a
+                  href="https://github.com"
+                  target="_blank"
+                  rel="noreferrer"
+                  className="text-muted-foreground hover:text-primary transition-colors"
+                >
+                  {t("Contribuir", "Contribute")}
+                </a>
+              </li>
+              <li>
+                <a
+                  href="https://github.com/roadmap"
+                  target="_blank"
+                  rel="noreferrer"
+                  className="text-muted-foreground hover:text-primary transition-colors"
+                >
+                  Roadmap
+                </a>
+              </li>
+              <li>
+                <a
+                  href="https://www.githubstatus.com/"
+                  target="_blank"
+                  rel="noreferrer"
+                  className="text-muted-foreground hover:text-primary transition-colors"
+                >
+                  Status
+                </a>
+              </li>
             </ul>
           </div>
         </div>
@@ -72,19 +142,21 @@ export function Footer() {
         <div className="glass-card mb-12">
           <div className="text-center">
             <h4 className="text-2xl font-space-grotesk font-bold mb-4 gradient-text">
-              Fique por dentro das novidades
+              {t("Fique por dentro das novidades", "Stay up to date with news")}
             </h4>
             <p className="text-muted-foreground mb-6 max-w-2xl mx-auto">
-              Receba atualizações sobre nossos projetos, novidades da comunidade e 
-              conteúdo exclusivo sobre desenvolvimento futurista.
+              {t(
+                "Receba atualizações sobre nossos projetos, novidades da comunidade e conteúdo exclusivo sobre desenvolvimento futurista.",
+                "Receive updates about our projects, community news, and exclusive content on futuristic development."
+              )}
             </p>
             <div className="flex flex-col sm:flex-row gap-4 max-w-md mx-auto">
-              <input 
-                type="email" 
-                placeholder="seu@email.com" 
+              <input
+                type="email"
+                placeholder={t("seu@email.com", "your@email.com")}
                 className="flex-1 px-4 py-3 bg-background/50 rounded-xl border border-border/50 focus:border-primary focus:outline-none"
               />
-              <Button variant="hero">Inscrever-se</Button>
+              <Button variant="hero">{t("Inscrever-se", "Subscribe")}</Button>
             </div>
           </div>
         </div>
@@ -92,14 +164,20 @@ export function Footer() {
         {/* Bottom Bar */}
         <div className="flex flex-col md:flex-row items-center justify-between pt-8 border-t border-border/30">
           <div className="flex items-center space-x-2 text-muted-foreground mb-4 md:mb-0">
-            <span>© 2024 Monynha Softwares. Feito com</span>
+            <span>© 2024 Monynha Softwares. {t("Feito com", "Made with")}</span>
             <Heart className="w-4 h-4 text-pink-400" />
-            <span>e muito café.</span>
+            <span>{t("e muito café.", "and lots of coffee.")}</span>
           </div>
           <div className="flex items-center space-x-6 text-sm text-muted-foreground">
-            <a href="#" className="hover:text-primary transition-colors">Privacidade</a>
-            <a href="#" className="hover:text-primary transition-colors">Termos</a>
-            <a href="#" className="hover:text-primary transition-colors">Cookies</a>
+            <a href="#" className="hover:text-primary transition-colors">
+              {t("Privacidade", "Privacy")}
+            </a>
+            <a href="#" className="hover:text-primary transition-colors">
+              {t("Termos", "Terms")}
+            </a>
+            <a href="#" className="hover:text-primary transition-colors">
+              {t("Cookies", "Cookies")}
+            </a>
           </div>
         </div>
 
@@ -107,7 +185,9 @@ export function Footer() {
         <div className="mt-8 text-center">
           <div className="inline-flex items-center glass px-4 py-2 rounded-full border border-primary/20">
             <span className="text-6xl mr-2">🏳️‍🌈</span>
-            <span className="text-sm font-medium">Proud to be inclusive • Orgulhosos de ser inclusivos</span>
+            <span className="text-sm font-medium">
+              {t("Orgulhosos de ser inclusivos", "Proud to be inclusive")}
+            </span>
           </div>
         </div>
       </div>

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -2,8 +2,10 @@ import { Button } from "@/components/ui/button";
 import { ArrowRight, Sparkles, Zap, Heart } from "lucide-react";
 import heroImage from "@/assets/hero-bg.jpg";
 import { Link } from "react-router-dom";
+import { useLanguage } from "@/hooks/useLanguage";
 
 export function Hero() {
+  const { t } = useLanguage();
   return (
     <section 
       id="home" 
@@ -26,7 +28,9 @@ export function Hero() {
           {/* Hero Badge */}
           <div className="inline-flex items-center glass px-4 py-2 rounded-full mb-8 border border-primary/20">
             <Sparkles className="w-4 h-4 text-primary mr-2" />
-            <span className="text-sm font-medium">Tecnologia Futurista • Open Source</span>
+            <span className="text-sm font-medium">
+              {t("Tecnologia Futurista • Código Aberto", "Futuristic Technology • Open Source")}
+            </span>
             <Heart className="w-4 h-4 text-secondary ml-2" />
           </div>
 
@@ -39,23 +43,28 @@ export function Hero() {
 
           {/* Subtitle */}
           <p className="text-xl md:text-2xl text-muted-foreground mb-8 max-w-3xl mx-auto leading-relaxed">
-            Criamos experiências digitais <span className="gradient-text font-semibold">futuristas</span> e 
-            <span className="gradient-text font-semibold"> inclusivas</span> com tecnologias de ponta. 
-            Desenvolvendo o futuro da web com amor e diversidade.
+            {t(
+              "Criamos experiências digitais ",
+              "We build digital experiences "
+            )}
+            <span className="gradient-text font-semibold">{t("futuristas", "futuristic")}</span>
+            {t(" e", " and")}
+            <span className="gradient-text font-semibold">{t(" inclusivas", " inclusive")}</span>
+            {t(" com tecnologias de ponta. Desenvolvendo o futuro da web com amor e diversidade.", " with cutting-edge technologies. Developing the future of the web with love and diversity.")}
           </p>
 
           {/* CTA Buttons */}
           <div className="flex flex-col sm:flex-row gap-4 justify-center items-center mb-12">
             <Button variant="hero" size="hero" className="group" asChild>
               <Link to="/projects">
-                Explorar Projetos
+                {t("Explorar Projetos", "Explore Projects")}
                 <ArrowRight className="w-5 h-5 group-hover:translate-x-1 transition-transform" />
               </Link>
             </Button>
             <Button variant="glass" size="hero" asChild>
               <Link to="/docs">
                 <Zap className="w-5 h-5 mr-2" />
-                Ver Documentação
+                {t("Ver Documentação", "View Documentation")}
               </Link>
             </Button>
           </div>

--- a/src/hooks/useLanguage.test.tsx
+++ b/src/hooks/useLanguage.test.tsx
@@ -1,0 +1,27 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { LanguageProvider, useLanguage } from './useLanguage';
+import React from 'react';
+
+function TestComponent() {
+  const { language, setLanguage, t } = useLanguage();
+  return (
+    <div>
+      <span>{t('Olá', 'Hello')}</span>
+      <button onClick={() => setLanguage(language === 'pt' ? 'en' : 'pt')}>toggle</button>
+    </div>
+  );
+}
+
+describe('useLanguage', () => {
+  it('switches language at runtime', () => {
+    render(
+      <LanguageProvider>
+        <TestComponent />
+      </LanguageProvider>
+    );
+    expect(screen.getByText('Olá')).toBeInTheDocument();
+    fireEvent.click(screen.getByText('toggle'));
+    expect(screen.getByText('Hello')).toBeInTheDocument();
+  });
+});

--- a/src/pages/Auth.tsx
+++ b/src/pages/Auth.tsx
@@ -7,9 +7,11 @@ import { Label } from '@/components/ui/label';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { toast } from 'sonner';
 import { Loader2, Lock, Mail } from 'lucide-react';
+import { useLanguage } from '@/hooks/useLanguage';
 
 export default function Auth() {
   const { user, loading, signIn, signUp } = useAuth();
+  const { t } = useLanguage();
   const [isLogin, setIsLogin] = useState(true);
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
@@ -39,7 +41,11 @@ export default function Auth() {
       if (error) {
         toast.error(error.message);
       } else {
-        toast.success(isLogin ? 'Signed in successfully!' : 'Account created! Check your email for verification.');
+        toast.success(
+          isLogin
+            ? t('Login realizado com sucesso!', 'Signed in successfully!')
+            : t('Conta criada! Verifique seu email para confirmação.', 'Account created! Check your email for verification.')
+        );
       }
     } finally {
       setIsSubmitting(false);
@@ -56,10 +62,14 @@ export default function Auth() {
             <Lock className="h-6 w-6 text-primary" />
           </div>
           <CardTitle className="text-2xl font-space-grotesk gradient-text">
-            {isLogin ? 'Admin Login' : 'Create Account'}
+            {isLogin
+              ? t('Entrar no Painel', 'Admin Login')
+              : t('Criar Conta', 'Create Account')}
           </CardTitle>
           <CardDescription>
-            {isLogin ? 'Sign in to access the admin panel' : 'Create your admin account'}
+            {isLogin
+              ? t('Faça login para acessar o painel admin', 'Sign in to access the admin panel')
+              : t('Crie sua conta de administrador', 'Create your admin account')}
           </CardDescription>
         </CardHeader>
         
@@ -72,7 +82,7 @@ export default function Auth() {
                 <Input
                   id="email"
                   type="email"
-                  placeholder="admin@example.com"
+                  placeholder={t('admin@exemplo.com', 'admin@example.com')}
                   value={email}
                   onChange={(e) => setEmail(e.target.value)}
                   className="pl-10"
@@ -82,7 +92,7 @@ export default function Auth() {
             </div>
             
             <div className="space-y-2">
-              <Label htmlFor="password">Password</Label>
+              <Label htmlFor="password">{t('Senha', 'Password')}</Label>
               <div className="relative">
                 <Lock className="absolute left-3 top-3 h-4 w-4 text-muted-foreground" />
                 <Input
@@ -103,7 +113,7 @@ export default function Auth() {
               disabled={isSubmitting}
             >
               {isSubmitting && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
-              {isLogin ? 'Sign In' : 'Create Account'}
+              {isLogin ? t('Entrar', 'Sign In') : t('Criar Conta', 'Create Account')}
             </Button>
           </form>
           
@@ -113,7 +123,9 @@ export default function Auth() {
               onClick={() => setIsLogin(!isLogin)}
               className="text-sm text-muted-foreground hover:text-primary transition-colors"
             >
-              {isLogin ? "Don't have an account? Sign up" : "Already have an account? Sign in"}
+              {isLogin
+                ? t('Não tem uma conta? Cadastre-se', "Don't have an account? Sign up")
+                : t('Já tem uma conta? Entre', 'Already have an account? Sign in')}
             </button>
           </div>
         </CardContent>

--- a/src/pages/NotFound.tsx
+++ b/src/pages/NotFound.tsx
@@ -13,7 +13,10 @@ const NotFound = () => {
 
   useEffect(() => {
     console.error(
-      "404 Error: User attempted to access non-existent route:",
+      t(
+        "Erro 404: usuário tentou acessar uma rota inexistente:",
+        "404 Error: User attempted to access non-existent route:"
+      ),
       location.pathname
     );
   }, [location.pathname]);

--- a/tests/admin-posts.spec.ts
+++ b/tests/admin-posts.spec.ts
@@ -1,5 +1,11 @@
 import { test, expect } from '@playwright/test';
 
+test.beforeEach(async ({ page }) => {
+  await page.addInitScript(() => {
+    window.localStorage.setItem('lang', 'en');
+  });
+});
+
 const SUPABASE_URL = 'https://fineleshydmsyjcvffye.supabase.co';
 
 test('admin can create post', async ({ page }) => {


### PR DESCRIPTION
## Summary
- localize About values and stats arrays with pt/en strings
- internationalize Footer, Hero, Auth, and NotFound components
- add unit test demonstrating runtime language switching
- ensure admin e2e tests force English locale for Sign In button

## Testing
- `./ci_test_local.sh`


------
https://chatgpt.com/codex/tasks/task_e_6898fb92ed008322a3847e0a63c2048a