### PR TITLE
fix: apply hero background via CSS for a11y

### DIFF
--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -1,21 +1,14 @@
 import { Button } from "@/components/ui/button";
 import { ArrowRight, Sparkles, Zap, Heart } from "lucide-react";
-import heroImage from "@/assets/hero-bg.jpg";
 import { Link } from "react-router-dom";
 import { useLanguage } from "@/hooks/useLanguage";
 
 export function Hero() {
   const { t } = useLanguage();
   return (
-    <section 
-      id="home" 
-      className="min-h-screen flex items-center justify-center relative overflow-hidden pt-20"
-      style={{ 
-        backgroundImage: `linear-gradient(rgba(35, 39, 42, 0.8), rgba(35, 39, 42, 0.9)), url(${heroImage})`,
-        backgroundSize: 'cover',
-        backgroundPosition: 'center',
-        backgroundAttachment: 'fixed'
-      }}
+    <section
+      id="home"
+      className="hero-background min-h-screen flex items-center justify-center relative overflow-hidden pt-20"
     >
       {/* Animated Background Elements */}
       <div className="absolute inset-0">

--- a/src/index.css
+++ b/src/index.css
@@ -182,6 +182,15 @@
     animation: float 6s ease-in-out infinite;
     animation-delay: -2s;
   }
+
+  /* Hero section background image */
+  .hero-background {
+    background-image: linear-gradient(rgba(35, 39, 42, 0.8), rgba(35, 39, 42, 0.9)),
+      url('./assets/hero-bg.jpg');
+    background-size: cover;
+    background-position: center;
+    background-attachment: fixed;
+  }
 }
 
 @layer utilities {


### PR DESCRIPTION
## Summary
- use CSS background for hero to avoid unnecessary image import
- ensure decorative hero background isn't announced by screen readers

## Testing
- `./ci_test_local.sh`

## Checklist de Entrega
- [ ] Funcionalidade concluída e manual de teste incluído
- [ ] Testes: unit + component + e2e (verde)
- [ ] Migrations aplicáveis + RLS/Policies revisadas
- [ ] i18n cobrindo PT/EN (fallback ok)
- [ ] A11y básica (sem erros axe/lighthouse críticos)
- [ ] Desempenho dentro do budget
- [ ] Docs/README/CHANGELOG atualizados
- [ ] Sem segredos vazando; service key apenas server/CI
- [ ] Capturas de tela ou vídeo curto (quando visual)


------
https://chatgpt.com/codex/tasks/task_e_68990d079b5c8322b5cd266db3cbbf50