### PR TITLE
feat(search): add full-text search with ranking

### DIFF
--- a/src/hooks/useSearch.test.tsx
+++ b/src/hooks/useSearch.test.tsx
@@ -1,0 +1,66 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, act, waitFor } from '@testing-library/react';
+
+vi.mock('@/integrations/supabase/client', () => ({
+  supabase: {
+    from: vi.fn(),
+  },
+}));
+
+const { supabase } = await import('@/integrations/supabase/client');
+import { useSearch } from './useSearch';
+
+describe('useSearch', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns ranked results limited to 10', async () => {
+    const blogPosts = Array.from({ length: 6 }, (_, i) => ({
+      id: `bp-${i}`,
+      title_pt: `Post ${i}`,
+      content_pt: '',
+      slug: `bp-${i}`,
+      published_at: null,
+      score: 1 - i * 0.1,
+    }));
+
+    const projects = Array.from({ length: 6 }, (_, i) => ({
+      id: `pr-${i}`,
+      name_pt: `Project ${i}`,
+      description_pt: '',
+      slug: `pr-${i}`,
+      score: 0.9 - i * 0.1,
+    }));
+
+    const dataMap: Record<string, any[]> = {
+      blog_posts: blogPosts,
+      projects,
+      docs: [],
+    };
+
+    (supabase.from as any).mockImplementation((table: string) => {
+      const chain = {
+        select: vi.fn().mockReturnThis(),
+        eq: vi.fn().mockReturnThis(),
+        textSearch: vi.fn().mockReturnThis(),
+        order: vi.fn().mockReturnThis(),
+        limit: vi.fn().mockResolvedValue({ data: dataMap[table], error: null }),
+      };
+      return chain;
+    });
+
+    const { result } = renderHook(() => useSearch());
+
+    await act(async () => {
+      await result.current.search('query');
+    });
+
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    expect(result.current.results).toHaveLength(10);
+    const scores = result.current.results.map(r => r.score);
+    expect(scores).toEqual([...scores].sort((a, b) => b - a));
+    expect(scores).not.toContain(0.4);
+  });
+});

--- a/supabase/migrations/20250812120000_add_search_vectors.sql
+++ b/supabase/migrations/20250812120000_add_search_vectors.sql
@@ -1,0 +1,21 @@
+-- Add tsvector search columns for full-text search
+alter table public.blog_posts
+  add column if not exists search_vector tsvector generated always as (
+    setweight(to_tsvector('simple', coalesce(title_pt,'') || ' ' || coalesce(title_en,'')), 'A') ||
+    setweight(to_tsvector('simple', coalesce(content_pt,'') || ' ' || coalesce(content_en,'')), 'B')
+  ) stored;
+create index if not exists idx_blog_posts_search_vector on public.blog_posts using GIN (search_vector);
+
+alter table public.projects
+  add column if not exists search_vector tsvector generated always as (
+    setweight(to_tsvector('simple', coalesce(name_pt,'') || ' ' || coalesce(name_en,'')), 'A') ||
+    setweight(to_tsvector('simple', coalesce(description_pt,'') || ' ' || coalesce(description_en,'')), 'B')
+  ) stored;
+create index if not exists idx_projects_search_vector on public.projects using GIN (search_vector);
+
+alter table public.docs
+  add column if not exists search_vector tsvector generated always as (
+    setweight(to_tsvector('simple', coalesce(title_pt,'') || ' ' || coalesce(title_en,'')), 'A') ||
+    setweight(to_tsvector('simple', coalesce(content_pt,'') || ' ' || coalesce(content_en,'')), 'B')
+  ) stored;
+create index if not exists idx_docs_search_vector on public.docs using GIN (search_vector);


### PR DESCRIPTION
## Summary
- add tsvector search columns and indexes for posts, projects and docs
- switch search hook to ranked full-text search returning top 10 results with score
- cover hook with unit test for basic relevance

## Testing
- `pnpm lint`
- `pnpm test`

## Checklist
- [x] Funcionalidade concluída e manual de teste incluído
- [ ] Testes: unit + component + e2e (verde)
- [x] Migrations aplicáveis + RLS/Policies revisadas
- [ ] i18n cobrindo PT/EN (fallback ok)
- [ ] A11y básica (sem erros axe/lighthouse críticos)
- [ ] Desempenho dentro do budget
- [ ] Docs/README/CHANGELOG atualizados
- [x] Sem segredos vazando; service key apenas server/CI
- [ ] Capturas de tela ou vídeo curto (quando visual)


------
https://chatgpt.com/codex/tasks/task_e_68990f494c408322bdb09a717d2dd8ad