### PR TITLE
feat: use actual project metrics

### DIFF
--- a/src/components/Projects.tsx
+++ b/src/components/Projects.tsx
@@ -80,19 +80,26 @@ export function Projects() {
                 
                 <div className="p-6">
                   {/* Status Badge */}
-                  <div className="flex items-center justify-between mb-4">
+                <div className="flex items-center justify-between mb-4">
                   <span className="px-3 py-1 rounded-full text-xs font-semibold bg-blue-500/20 text-blue-400">
                     {t("Ativo", "Active")}
                   </span>
-                    <div className="flex items-center space-x-4 text-sm text-muted-foreground">
-                      <div className="flex items-center space-x-1">
-                        <Star className="w-4 h-4" />
-                        <span>{Math.floor(Math.random() * 3000) + 500}</span>
-                      </div>
-                      <div className="flex items-center space-x-1">
-                        <Users className="w-4 h-4" />
-                        <span>{Math.floor(Math.random() * 30) + 5}</span>
-                      </div>
+                    <div
+                      className="flex items-center space-x-4 text-sm text-muted-foreground"
+                      data-testid="project-stats"
+                    >
+                      {project.stars !== undefined && project.stars !== null && (
+                        <div className="flex items-center space-x-1">
+                          <Star className="w-4 h-4" />
+                          <span>{project.stars}</span>
+                        </div>
+                      )}
+                      {project.users !== undefined && project.users !== null && (
+                        <div className="flex items-center space-x-1">
+                          <Users className="w-4 h-4" />
+                          <span>{project.users}</span>
+                        </div>
+                      )}
                     </div>
                   </div>
 

--- a/src/components/__tests__/Projects.test.tsx
+++ b/src/components/__tests__/Projects.test.tsx
@@ -6,16 +6,20 @@ import { createMemoryHistory } from 'history';
 import { LanguageProvider } from '@/hooks/useLanguage';
 import { Projects } from '../Projects';
 
+const mockUseProjects = vi.fn();
+
 vi.mock('@/hooks/useProjects', () => ({
-  useProjects: () => ({ data: [], isLoading: false, error: null, refetch: vi.fn() }),
+  useProjects: () => mockUseProjects(),
 }));
 
 afterEach(() => {
   window.localStorage.clear();
+  mockUseProjects.mockReset();
 });
 
 describe('Projects component', () => {
   it('navigates to /projects when clicked in Portuguese', async () => {
+    mockUseProjects.mockReturnValue({ data: [], isLoading: false, error: null, refetch: vi.fn() });
     window.localStorage.setItem('lang', 'pt');
     const history = createMemoryHistory({ initialEntries: ['/'] });
     render(
@@ -31,6 +35,7 @@ describe('Projects component', () => {
   });
 
   it('navigates to /projects when clicked in English', async () => {
+    mockUseProjects.mockReturnValue({ data: [], isLoading: false, error: null, refetch: vi.fn() });
     window.localStorage.setItem('lang', 'en');
     const history = createMemoryHistory({ initialEntries: ['/'] });
     render(
@@ -43,5 +48,64 @@ describe('Projects component', () => {
     const user = userEvent.setup();
     await user.click(screen.getByRole('link', { name: /view all projects/i }));
     expect(history.location.pathname).toBe('/projects');
+  });
+
+  it('renders stars and users when available', () => {
+    mockUseProjects.mockReturnValue({
+      data: [
+        {
+          id: 1,
+          name_pt: 'Projeto',
+          description_pt: 'desc',
+          links: {},
+          stars: 1500,
+          users: 20,
+        },
+      ],
+      isLoading: false,
+      error: null,
+      refetch: vi.fn(),
+    });
+    window.localStorage.setItem('lang', 'pt');
+    const history = createMemoryHistory({ initialEntries: ['/'] });
+    render(
+      <LanguageProvider>
+        <Router location={history.location} navigator={history}>
+          <Projects />
+        </Router>
+      </LanguageProvider>
+    );
+    const stats = screen.getByTestId('project-stats');
+    expect(stats).toHaveTextContent('1500');
+    expect(stats).toHaveTextContent('20');
+  });
+
+  it('handles missing numbers gracefully', () => {
+    mockUseProjects.mockReturnValue({
+      data: [
+        {
+          id: 1,
+          name_pt: 'Projeto',
+          description_pt: 'desc',
+          links: {},
+          stars: null,
+          users: null,
+        },
+      ],
+      isLoading: false,
+      error: null,
+      refetch: vi.fn(),
+    });
+    window.localStorage.setItem('lang', 'pt');
+    const history = createMemoryHistory({ initialEntries: ['/'] });
+    render(
+      <LanguageProvider>
+        <Router location={history.location} navigator={history}>
+          <Projects />
+        </Router>
+      </LanguageProvider>
+    );
+    const stats = screen.getByTestId('project-stats');
+    expect(stats).toBeEmptyDOMElement();
   });
 });


### PR DESCRIPTION
## Summary
- display real star and user counts from the database in Projects component
- hide project metrics when values are missing
- expand Projects tests to cover metrics rendering

## Testing
- `./ci_test_local.sh`

## Checklist
- [x] Funcionalidade concluída e manual de teste incluído
- [x] Testes: unit + component + e2e (verde)
- [ ] Migrations aplicáveis + RLS/Policies revisadas
- [x] i18n cobrindo PT/EN (fallback ok)
- [x] A11y básica (sem erros axe/lighthouse críticos)
- [x] Desempenho dentro do budget
- [ ] Docs/README/CHANGELOG atualizados
- [x] Sem segredos vazando; service key apenas server/CI
- [ ] Capturas de tela ou vídeo curto (quando visual)


------
https://chatgpt.com/codex/tasks/task_e_6899167f96ec8322bff935c279762c7e