### PR TITLE
chore(router): enable React Router v7 future flags

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -41,7 +41,12 @@ const App = () => (
         <TooltipProvider>
           <Toaster />
           <Sonner />
-          <BrowserRouter>
+          <BrowserRouter
+            future={{
+              v7_startTransition: true,
+              v7_relativeSplatPath: true,
+            }}
+          >
             <ErrorBoundary>
               <Routes>
                 <Route path="/" element={<Index />} />

--- a/src/pages/ErrorBoundary.test.tsx
+++ b/src/pages/ErrorBoundary.test.tsx
@@ -22,7 +22,10 @@ const renderWithLang = (lang: 'pt' | 'en') => {
   render(
     <LanguageProvider>
       <LanguageSetter lang={lang} />
-      <MemoryRouter initialEntries={["/"]}>
+      <MemoryRouter
+        initialEntries={["/"]}
+        future={{ v7_startTransition: true, v7_relativeSplatPath: true }}
+      >
         <Routes>
           <Route
             path="/"

--- a/src/pages/admin/BlogPosts.test.tsx
+++ b/src/pages/admin/BlogPosts.test.tsx
@@ -79,7 +79,7 @@ describe('Admin BlogPosts page', () => {
   it('renders published and draft badges', () => {
     render(
       <QueryClientProvider client={queryClient}>
-        <MemoryRouter>
+        <MemoryRouter future={{ v7_startTransition: true, v7_relativeSplatPath: true }}>
           <BlogPosts />
         </MemoryRouter>
       </QueryClientProvider>
@@ -93,7 +93,7 @@ describe('Admin BlogPosts page', () => {
     const spy = vi.spyOn(queryClient, 'setQueryData');
     render(
       <QueryClientProvider client={queryClient}>
-        <MemoryRouter>
+        <MemoryRouter future={{ v7_startTransition: true, v7_relativeSplatPath: true }}>
           <BlogPosts />
         </MemoryRouter>
       </QueryClientProvider>


### PR DESCRIPTION
## Summary
- enable React Router v7 `future` flags in main router
- update tests to include future flags

## Testing
- `./ci_test_local.sh`

## Checklist
- [x] Funcionalidade concluída e manual de teste incluído
- [x] Testes: unit + component + e2e (verde)
- [ ] Migrations aplicáveis + RLS/Policies revisadas
- [ ] i18n cobrindo PT/EN (fallback ok)
- [ ] A11y básica (sem erros axe/lighthouse críticos)
- [ ] Desempenho dentro do budget
- [ ] Docs/README/CHANGELOG atualizados
- [x] Sem segredos vazando; service key apenas server/CI
- [ ] Capturas de tela ou vídeo curto (quando visual)


------
https://chatgpt.com/codex/tasks/task_e_6899af1839e8832294d6c07168d34cf9